### PR TITLE
INACTIVE: ZOS Xlp Codecache and ObjectHeap Changes

### DIFF
--- a/docs/xlpcodecache.md
+++ b/docs/xlpcodecache.md
@@ -32,13 +32,9 @@ To find out the large page sizes available and the current setting, use the `-ve
 
 ## Syntax
 
-AIX&reg;, Linux&reg;, macOS&reg;, and Windows&trade;:
+AIX&reg;, Linux&reg;, macOS&reg;, Windows&trade; and Z/OS&reg;:
 
         -Xlp:codecache:pagesize=<size>
-
-z/OS&reg;:
-
-        -Xlp:codecache:pagesize=<size>,pageable
 
 See [Using -X command-line options](x_jvm_commands.md) for more information about the `<size>` parameter.
 
@@ -67,7 +63,7 @@ See [Using -X command-line options](x_jvm_commands.md) for more information abou
 
 : 1 MB pageable pages, when available, are the default size for the code cache.
 
-    The `-Xlp:codecache:pagesize=<size>,pageable` option supports only a large page size of 1 MB pageable large pages. The use of 1 MB pageable large pages for the JIT code cache can improve the runtime performance of some Java&trade; applications. A page size of 4 KB can also be used.
+    The `-Xlp:codecache:pagesize=<size>` option supports only a large page size of 1 MB pageable large pages. The use of 1 MB pageable large pages for the JIT code cache can improve the runtime performance of some Java&trade; applications. A page size of 4 KB can also be used.
 
 ## See also
 

--- a/docs/xlpcodecache.md
+++ b/docs/xlpcodecache.md
@@ -32,8 +32,6 @@ To find out the large page sizes available and the current setting, use the `-ve
 
 ## Syntax
 
-AIX&reg;, Linux&reg;, macOS&reg;, Windows&trade; and Z/OS&reg;:
-
         -Xlp:codecache:pagesize=<size>
 
 See [Using -X command-line options](x_jvm_commands.md) for more information about the `<size>` parameter.

--- a/docs/xlpobjectheap.md
+++ b/docs/xlpobjectheap.md
@@ -31,8 +31,6 @@ To find out the large page sizes available and the current setting, use the `-ve
 
 ## Syntax
 
-AIX&reg;, Linux&reg;, macOS&reg;, Windows&trade; and Z/OS&reg;:
-
         -Xlp:objectheap:pagesize=<size>[,strict|warn]
 
 See [Using -X command-line options](x_jvm_commands.md) for more information about the `<size>` parameter.

--- a/docs/xlpobjectheap.md
+++ b/docs/xlpobjectheap.md
@@ -31,13 +31,9 @@ To find out the large page sizes available and the current setting, use the `-ve
 
 ## Syntax
 
-AIX&reg;, Linux&reg;, macOS&reg;, and Windows&trade;:
+AIX&reg;, Linux&reg;, macOS&reg;, Windows&trade; and Z/OS&reg;:
 
         -Xlp:objectheap:pagesize=<size>[,strict|warn]
-
-z/OS&reg;:
-
-        -Xlp:objectheap:pagesize=<size>[,strict|warn][,pageable|nonpageable]
 
 See [Using -X command-line options](x_jvm_commands.md) for more information about the `<size>` parameter.
 
@@ -60,6 +56,8 @@ See [Using -X command-line options](x_jvm_commands.md) for more information abou
     - On other architectures, the VM uses the default operating system page size.
 
 : On macOS, the default page size is 4 KB.
+
+: On Z/OS&reg If both 1M pageable, and nonpageable large pages are available then 1M pageable large pages will be used by default if [non]pageable is not specified.
 
 ### `strict` | `warn`
 


### PR DESCRIPTION
Z/OS now supports the same command line argument format as other architectures for both -Xlp:codecache, and -Xlp:objectheap.

The behaviour is slightly different with the objectheap, where pagrable large files are always preferred over nonpageable when [non]pageable is not specified.

Signed-off-by: AlenBadel <Alen.Badel@ibm.com>