### PR TITLE
Improve mapping of GC policies to GC options

### DIFF
--- a/docs/xalwaysclassgc.md
+++ b/docs/xalwaysclassgc.md
@@ -22,9 +22,9 @@
 * Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
 -->
 
-# -Xalwaysclassgc 
+# -Xalwaysclassgc
 
-Always perform dynamic class unloading checks during global garbage collection.
+Always perform dynamic class unloading during global garbage collection.
 
 ## Syntax
 
@@ -34,8 +34,10 @@ Always perform dynamic class unloading checks during global garbage collection.
 
 If you don't set this option, the default behavior is defined by [`-Xclassgc`](xclassgc.md).
 
+This option can be used with all OpenJ9 GC policies.
 
+## See also
 
+- [`-Xclassgc`/`-Xnoclassgc`](xclassgc.md)
 
 <!-- ==== END OF TOPIC ==== xalwaysclassgc.md ==== -->
-

--- a/docs/xclassgc.md
+++ b/docs/xclassgc.md
@@ -24,20 +24,24 @@
 
 # -Xclassgc / -Xnoclassgc
 
-Enables and disables class garbage collection (the dynamic unloading of class objects by the VM). 
+Enables and disables the garbage collection (GC) of storage that is associated with Java classes that are no longer being used by the OpenJ9 VM.
 
-When enabled, garbage collection, occurs only on class loader changes. This is the default behavior.
+When enabled, GC occurs only on class loader changes. To always enable dynamic class unloading regardless of class loader changes, set [`-Xalwaysclassgc`](xalwaysclassgc.md).
 
-:fontawesome-solid-pencil-alt:{: .note aria-hidden="true"} **Note:** Disabling class garbage collection is not recommended as this causes unlimited native memory growth, leading to out-of-memory errors.
+:fontawesome-solid-pencil-alt:{: .note aria-hidden="true"} **Note:** Disabling class GC is not recommended because unlimited native memory growth can occur, which can lead to out-of-memory errors.
 
 ## Syntax
 
 | Setting      | Action     | Default                                                                            |
 |--------------|------------|:----------------------------------------------------------------------------------:|
-|`-Xclassgc`   | Enable GC  | :fontawesome-solid-check:{: .yes aria-hidden="true"}<span class="sr-only">yes</span> |
-|`-Xnoclassgc` | Disable GC |                                                                                    |
+|`-Xclassgc`   | Enables dynamic class unloading on demand  | :fontawesome-solid-check:{: .yes aria-hidden="true"}<span class="sr-only">yes</span> |
+|`-Xnoclassgc` | Disables dynamic class unloading |                                                                                    |
 
+These options can be used with all OpenJ9 GC policies.
 
+## See also
+
+- [`-Xalwaysclassgc`](xalwaysclassgc.md)
 
 <!-- ==== END OF TOPIC ==== xclassgc.md ==== -->
 <!-- ==== END OF TOPIC ==== xnoclassgc.md ==== -->

--- a/docs/xcompactgc.md
+++ b/docs/xcompactgc.md
@@ -22,10 +22,10 @@
 * Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
 -->
 
-# -Xcompactgc / -Xnocompactgc 
+# -Xcompactgc / -Xnocompactgc
 
 
-Enables or disables full compaction on all garbage collections (system and global).
+Enables or disables full compaction on system and global garbage collection (GC) activities.
 
 ## Syntax
 
@@ -37,13 +37,17 @@ Enables or disables full compaction on all garbage collections (system and globa
 
 ## Default behavior
 
-If no compaction option is specified, the garbage collector compacts based on a series of triggers that attempt to compact only when it is beneficial to the future performance of the OpenJ9 VM.
+If a compaction option is not specified, the garbage collector compacts based on a series of triggers. These triggers attempt to compact only when it is beneficial to the future performance of the VM.
+
+These options are not applicable to the following GC policies:
+
+- balanced GC policy (`-Xgcpolicy:balanced`): compaction is always enabled.
+- metronome GC policy (`-Xgcpolicy:metronome`): compaction is not supported.
 
 ## See also
 
-- [Global garbage collection: Compaction phase](https://www.ibm.com/support/knowledgecenter/SSYKE2_8.0.0/com.ibm.java.vm.80.doc/docs/mm_gc_compact.html)
+- [GC compact operation](gc_overview.md#gc-compact-operation)
 
 
 <!-- ==== END OF TOPIC ==== xcompactgc.md ==== -->
 <!-- ==== END OF TOPIC ==== xnocompactgc.md ==== -->
-

--- a/docs/xconcurrentbackground.md
+++ b/docs/xconcurrentbackground.md
@@ -24,7 +24,7 @@
 
 # -Xconcurrentbackground
 
-Specifies the number of low-priority background threads attached to assist the mutator threads in concurrent mark.
+Specifies the number of low-priority background threads that are attached to assist the mutator threads in concurrent mark operations. This option maps directly to the HotSpot `-XX:ParallelCMSThreads=N` and `-XX:ConcGCThreads=N` options.
 
 ## Syntax
 
@@ -35,5 +35,12 @@ Specifies the number of low-priority background threads attached to assist the m
 The default value is `1`.
 
 :fontawesome-solid-pencil-alt:{: .note aria-hidden="true"} **Note:** This value is reported in the header section of a verbose GC log with the entry `<attribute name="gcthreads Concurrent Mark" value="1" />`.
+
+This option is not supported with the balanced GC policy (`-Xgcpolicy:balanced`) or metronome GC policy (`-Xgcpolicy:metronome`).
+
+## See also
+
+- [`-XX:ParallelCMSThreads`](xxparallelcmsthreads.md)
+- [`-XX:ConcGCThreads`](xxconcgcthreads.md)
 
 <!-- ==== END OF TOPIC ==== xconcurrentbackground.md ==== -->

--- a/docs/xconcurrentlevel.md
+++ b/docs/xconcurrentlevel.md
@@ -22,9 +22,9 @@
 * Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
 -->
 
-# -Xconcurrentlevel 
+# -Xconcurrentlevel
 
-This option indicates the ratio between the amount of heap allocated and the amount of heap marked (the allocation "tax" rate).
+This option indicates the ratio between the amount of heap allocated and the amount of heap marked, which is known as the *allocation tax* rate.
 
 ## Syntax
 
@@ -34,7 +34,8 @@ This option indicates the ratio between the amount of heap allocated and the amo
 
 The default is 8.
 
+This option is not supported with the balanced GC policy (`-Xgcpolicy:balanced`) or metronome GC policy (`-Xgcpolicy:metronome`).
+
 
 
 <!-- ==== END OF TOPIC ==== xconcurrentlevel.md ==== -->
-

--- a/docs/xconcurrentslack.md
+++ b/docs/xconcurrentslack.md
@@ -22,11 +22,11 @@
 * Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
 -->
 
-# -Xconcurrentslack 
+# -Xconcurrentslack
 
 Attempts to keep the specified amount of the heap space free in concurrent collectors by starting the concurrent operations earlier.
 
-Using this option can sometimes alleviate pause time problems in concurrent collectors at the cost of longer concurrent cycles, affecting total throughput. 
+Using this option can sometimes alleviate pause time problems in concurrent collectors at the cost of longer concurrent cycles, affecting total throughput.
 
 ## Syntax
 
@@ -38,7 +38,8 @@ Using this option can sometimes alleviate pause time problems in concurrent coll
 
 The default value is 0, which is optimal for most applications.
 
+This option is not supported with the balanced GC policy (`-Xgcpolicy:balanced`), the *optimize for throughput* policy (`-Xgcpolicy:optthruput`), or metronome GC policy (`-Xgcpolicy:metronome`).
+
 
 
 <!-- ==== END OF TOPIC ==== xconcurrentslack.md ==== -->
-

--- a/docs/xconmeter.md
+++ b/docs/xconmeter.md
@@ -22,9 +22,9 @@
 * Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
 -->
 
-# -Xconmeter 
+# -Xconmeter
 
-This option determines the usage of which area, LOA (large object area) or SOA (small object area), is metered and hence which allocations are taxed during concurrent mark.
+This option determines the usage of which area, LOA (large object area) or SOA (small object area), is metered and therefore which allocations are taxed during concurrent mark operations.
 
 ## Syntax
 
@@ -54,6 +54,7 @@ This option determines the usage of which area, LOA (large object area) or SOA (
 
 By default, allocation tax is applied to the SOA.
 
+This option is not supported with the balanced GC policy (`-Xgcpolicy:balanced`) or metronome GC policy (`-Xgcpolicy:metronome`).
+
 
 <!-- ==== END OF TOPIC ==== xconmeter.md ==== -->
-

--- a/docs/xenableexcessivegc.md
+++ b/docs/xenableexcessivegc.md
@@ -37,7 +37,7 @@ If excessive time is spent in the GC, the option returns `null` for an allocate 
 |`-Xenableexcessivegc`  | Enable exception  | :fontawesome-solid-check:{: .yes aria-hidden="true"}<span class="sr-only">yes</span>     |
 |`-Xdisableexcessivegc` | Disable exception |                                                                                    |
 
-
+These options can be used with all OpenJ9 GC policies.
 
 <!-- ==== END OF TOPIC ==== xenableexcessivegc.md ==== -->
 <!-- ==== END OF TOPIC ==== xdisableexcessivegc.md ==== -->

--- a/docs/xenableexplicitgc.md
+++ b/docs/xenableexplicitgc.md
@@ -40,6 +40,7 @@ Although it is possible to programmatically trigger a global GC by calling `Syst
 
 The default for all OpenJ9 GC policies is `-Xenableexplicitgc` except for [`-Xgcpolicy:nogc`](xgcpolicy.md#nogc), where the default is `-Xdisableexplicitgc`.
 
+These options can be used with all OpenJ9 GC policies.
 
 <!-- ==== END OF TOPIC ==== xenableexplicitgc.md ==== -->
 <!-- ==== END OF TOPIC ==== xdisableexplicitgc.md ==== -->

--- a/docs/xenablestringconstantgc.md
+++ b/docs/xenablestringconstantgc.md
@@ -22,7 +22,7 @@
 * Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
 -->
 
-# ‑Xenablestringconstantgc / ‑Xdisablestringconstantgc 
+# ‑Xenablestringconstantgc / ‑Xdisablestringconstantgc
 
 Enables or disables the collection of strings from the string intern table.
 
@@ -33,6 +33,7 @@ Enables or disables the collection of strings from the string intern table.
 | `-Xenablestringconstantgc`  | Enable collection  | :fontawesome-solid-check:{: .yes aria-hidden="true"}<span class="sr-only">yes</span> |
 | `-Xdisablestringconstantgc` | Disable collection |                                                                                    |
 
+This option is not supported with the balanced GC policy (`-Xgcpolicy:balanced`).
+
 <!-- ==== END OF TOPIC ==== xenablestringconstantgc.md ==== -->
 <!-- ==== END OF TOPIC ==== xdisablestringconstantgc.md ==== -->
-

--- a/docs/xgc.md
+++ b/docs/xgc.md
@@ -45,16 +45,20 @@ Options that change the behavior of the garbage collector.
 | [`minContractPercent`               ](#mincontractpercent               ) | Sets the minimum percentage of the heap that can be contracted at any given time.                         |
 | [`maxContractPercent`               ](#maxcontractpercent               ) | Sets the maximum percentage of the heap that can be contracted at any given time.                         |
 | [`noConcurrentScavenge`             ](#noconcurrentscavenge             ) | Disables concurrent scavenge.                                                                             |
+| [`noSynchronousGCOnOOM`             ](#nosynchronousgconoom             ) | Prevents an application stopping to allow GC activity.                                                                             |
 | [`overrideHiresTimerCheck`          ](#overridehirestimercheck          ) | Overrides GC operating system checks for timer resolution.                                                |
 | [`preferredHeapBase`                ](#preferredheapbase                ) | Sets a memory range for the Java&trade; heap. (AIX&reg;, Linux&reg;, macOS&reg;, and Windows&trade; only) |
 | [`scvNoAdaptiveTenure`              ](#scvnoadaptivetenure              ) | Turns off the adaptive tenure age in the generational concurrent GC policy.                               |
 | [`scvTenureAge`                     ](#scvtenureage                     ) | Sets the initial scavenger tenure age in the generational concurrent GC policy.                           |
 | [`stdGlobalCompactToSatisfyAllocate`](#stdglobalcompacttosatisfyallocate) | Prevents the GC from performing a compaction unless absolutely required.                                  |
+| [`synchronousGCOnOOM`               ](#synchronousgconoom               )     | Stops an application to allow GC activity.                                                                             |
+| [`targetPausetime`                  ](#targetpausetime                  )   | Sets the GC pause time for the `metronome` GC policy.                                                   |
+| [`targetUtilization`                ](#targetutilization                )   | Sets application utilization for the `metronome` GC policy.                                                   |
 | [`tlhIncrementSize`                 ](#tlhincrementsize                 ) | Sets the size of the thread local heap (TLH) increment.                                                   |
 | [`tlhInitialSize`                   ](#tlhinitialsize                   ) | Sets the initial size of the thread local heap.                                                           |
 | [`tlhMaximumSize`                   ](#tlhmaximumsize                   ) | Sets the maximum size of the thread local heap.                                                           |
 | [`verboseFormat`                    ](#verboseformat                    ) | Sets the verbose GC format.                                                                               |
-
+| [`verbosegcCycleTime`               ](#verbosegccycletime                    ) | Sets the criteria for verbose GC logging.                                                                              |
 
 ### `breadthFirstScanOrdering`
 
@@ -70,7 +74,7 @@ Options that change the behavior of the garbage collector.
 
 : This option sets a threshold that is used to start an early concurrent global GC cycle due to recent class loading activity. The default value is 80000.
 
-: This option  is applicable to the following GC policies: `gencon` and `optavgpause`.
+: This option is applicable to the following GC policies: `gencon` and `optavgpause`.
 
 ### `classUnloadingThreshold`
 
@@ -80,7 +84,7 @@ Options that change the behavior of the garbage collector.
 
 : This option sets a threshold that is used to trigger an optional GC class unloading operation in a global GC cycle, irrespective of how the global GC cycle is triggered. The default value is 6.
 
-: This option  is applicable to the following GC policies: `gencon`, `optavgpause`, and `optthruput`.
+: This option is applicable to the following GC policies: `gencon`, `optavgpause`, and `optthruput`.
 
 ### `concurrentScavenge`
 
@@ -88,7 +92,7 @@ Options that change the behavior of the garbage collector.
 
         -Xgc:concurrentScavenge
 
-: This option supports pause-less garbage collection mode when you use the Generational Concurrent ([`gencon`](xgcpolicy.md#gencon)) garbage collection policy (the default policy).
+: This option supports pause-less garbage collection mode when you use the Generational Concurrent ([`gencon`](xgcpolicy.md#gencon)) garbage collection policy (the default policy). This option cannot be used with any other GC policies.
 
     If you set this option, the VM attempts to reduce GC pause times for response-time sensitive, large-heap applications. This mode can be enabled with hardware-based support (Linux on IBM Z&reg; and z/OS&reg;) and software-based support (64-bit: Linux on (x86-64, POWER&reg;, IBM Z&reg;) AIX&reg;, macOS&reg;, and z/OS).
 
@@ -125,6 +129,8 @@ Options that change the behavior of the garbage collector.
 
 : The maximum amount of time spent on garbage collection of the nursery area, expressed as a percentage of the overall time for the last three GC intervals.
 
+: This option applies only to the `gencon` GC policy.
+
 ### `dnssExpectedTimeRatioMinimum`
 
         -Xgc:dnssExpectedTimeRatioMinimum=<value>
@@ -134,6 +140,8 @@ Options that change the behavior of the garbage collector.
   | `<value>`     | [percentage]   | 1                     |
 
 : The minimum amount of time spent on garbage collection of the nursery area, expressed as a percentage of the overall time for the last three GC intervals.
+
+: This option applies only to the `gencon` GC policy.
 
 <!--### `dynamicBreadthFirstScanOrdering`
 
@@ -153,6 +161,8 @@ Options that change the behavior of the garbage collector.
 
     The default value is 95, which means that anything over 5% of total application run time spent on GC is deemed excessive. This option can be used only when [`-Xenableexcessivegc`](xenableexcessivegc.md) is set (enabled by default).
 
+: This option can be used with all OpenJ9 GC policies.
+
 ### `hierarchicalScanOrdering`
 
         -Xgc:hierarchicalScanOrdering
@@ -169,6 +179,8 @@ Options that change the behavior of the garbage collector.
 
 : The minimum percentage of the heap that can be contracted at any given time.
 
+: This option can be used with all OpenJ9 GC policies.
+
 ### `maxContractPercent`
 
         -Xgc:maxContractPercent=<n>
@@ -179,15 +191,25 @@ Options that change the behavior of the garbage collector.
 
 : The maximum percentage of the heap that can be contracted at any given time. For example, `-Xgc:maxContractPercent=20` causes the heap to contract by as much as 20%.
 
+: This option can be used with all OpenJ9 GC policies.
+
 ### `noConcurrentScavenge`
 
 **(64-bit only)**
 
         -Xgc:noConcurrentScavenge
 
-: This option disables pause-less garbage collection that you might have enabled with the [`-Xgc:concurrentScavenge`](#concurrentscavenge) option when using the Generational Concurrent ([`gencon`](xgcpolicy.md#gencon)) garbage collection policy (the default policy).
+: This option disables pause-less garbage collection that you might have enabled with the [`-Xgc:concurrentScavenge`](#concurrentscavenge) option when using the default [`gencon`](xgcpolicy.md#gencon) GC policy. This option applies only to the `gencon` GC policy.
 
     :fontawesome-solid-pencil-alt:{: .note aria-hidden="true"} **Note:** No concurrent scavenge is the default state, but the `noConcurrentScavenge` option is useful as it will disable concurrent scavenge even if it has been enabled by a previous option; the right-most option always takes precedence.
+
+### `nosynchronousGCOnOOM`
+
+        -Xgc:nosynchronousGCOnOOM
+
+: Setting `-Xgc:nosynchronousGCOnOOM` implies that when heap memory is full your application stops and issues an *out-of-memory* message. The default is [`-Xgc:synchronousGCOnOOM`](#synchronousgconoom).
+
+: This option applies only to the `metronome` GC policy.
 
 ### `overrideHiresTimerCheck`
 
@@ -196,6 +218,8 @@ Options that change the behavior of the garbage collector.
 : When the VM starts, the GC checks that the operating system can meet the timer resolution requirements for the requested target pause time. Typically, this check correctly identifies operating systems that can deliver adequate time resolution. However, in some cases the operating system provides a more conservative answer than strictly necessary for GC pause time management, which prevents startup. Specifying this parameter causes the GC to ignore the answer returned by the operating system. The VM starts, but GC pause time management remains subject to operating system performance, which might not provide adequate timer resolution.
 
     :fontawesome-solid-pencil-alt:{: .note aria-hidden="true"} **Note:** Use this option with caution, and only when you are unable to use a supported operating system.
+
+: This option applies only to the `metronome` GC policy.
 
 ### `preferredHeapBase`
 
@@ -213,11 +237,15 @@ Options that change the behavior of the garbage collector.
 
     If the heap cannot be allocated in a contiguous block at the `preferredHeapBase` address you specified, an error occurs detailing a Garbage Collection (GC) allocation failure startup. When the `preferredHeapBase` option is used with the [`-Xlp`](xlp.md) option, the `preferredHeapBase` address must be a multiple of the large page size. If you specify an inaccurate heap base address, the heap is allocated with the default page size.
 
+: This option can be used with all OpenJ9 GC policies.
+
 ### `scvNoAdaptiveTenure`
 
         -Xgc:scvNoAdaptiveTenure
 
-: Turns off the adaptive tenure age in the generational concurrent GC policy. The initial age that is set is maintained throughout the run time of the VM. See `scvTenureAge`.
+: Turns off the adaptive tenure age in the `gencon` GC policy. The initial age that is set is maintained throughout the run time of the VM. See `scvTenureAge`.
+
+: This option applies only to the `gencon` GC policy.
 
 ### `scvTenureAge`
 
@@ -227,7 +255,9 @@ Options that change the behavior of the garbage collector.
   |---------------|----------------|-----------------------|
   | `<n>`         | [1 - 14]       | 10                    |
 
-: Sets the initial scavenger tenure age in the generational concurrent GC policy. For more information, see [`gencon` policy (default)](gc.md#gencon-policy-default).
+: Sets the initial scavenger tenure age in the `gencon` GC policy. For more information, see [`gencon` policy (default)](gc.md#gencon-policy-default).
+
+: This option applies only to the `gencon` GC policy.
 
 ### `stdGlobalCompactToSatisfyAllocate`
 
@@ -240,6 +270,36 @@ the dynamic compaction triggers that look at heap occupancy. This option works o
 - `optthruput`
 - `optavgpause`
 
+: This option is not supported with the balanced GC policy (`-Xgcpolicy:balanced`) or metronome GC policy (`-Xgcpolicy:metronome`).
+
+
+### `synchronousGCOnOOM`
+
+        -Xgc:synchronousGCOnOOM
+
+: GC cycles can occur when the Java heap runs out of memory. If there is no more free space in the heap, using `-Xgc:synchronousGCOnOOM` stops your application while GC operations remove unused objects. If free space runs out again, consider decreasing the target utilization to allow GC operations more time to complete. Setting `-Xgc:nosynchronousGCOnOOM` implies that when heap memory is full your application stops and issues an *out-of-memory* message. The default is `-Xgc:synchronousGCOnOOM`.
+
+: This option applies only to the `metronome` GC policy.
+
+### `targetPausetime`
+
+        -Xgc:targetPausetime=N
+
+: Sets the GC pause time, where `N` is the time in milliseconds. When this option is specified, the garbage collector operates with pauses that do not exceed the value specified. If this option is not specified the default pause time is set to 3 milliseconds. For example, running with `-Xgc:targetPausetime=20` causes the garbage collector to pause for no longer than 20 milliseconds during GC operations.
+
+: This option applies only to the `metronome` GC policy.
+
+### `targetUtilization`
+
+        -Xgc:targetUtilization=N
+
+: Sets the application utilization to `N%`; the garbage collector attempts to use at most (100-N)% of each time interval. Reasonable values are in the range of 50-80%. Applications with low allocation rates might be able to run at 90%. The default is 70%.
+
+    In the following example, the maximum size of the heap is set to 30 MB. The garbage collector attempts to use 25% of each time interval because the target utilization for the application is set to 75%.
+
+        java -Xgcpolicy:metronome -Xmx30m -Xgc:targetUtilization=75 Test
+
+: This option applies only to the `metronome` GC policy.
 
 ### `tlhIncrementSize`
 
@@ -247,11 +307,15 @@ the dynamic compaction triggers that look at heap occupancy. This option works o
 
 : Sets the increment size of the thread local heap (TLH), which plays a key role in cache allocation. Threads start creating TLHs with a predefined initial size (default 2 KB). On every TLH refresh, the requested size for that thread is increased by an increment (default 4 KB). Use this option to control the increment size.
 
+: This option can be used with all OpenJ9 GC policies.
+
 ### `tlhInitialSize`
 
         -Xgc:tlhInitialSize=<bytes>
 
 : Sets the initial size of the TLH. The default size is 2 KB.
+
+: This option can be used with all OpenJ9 GC policies.
 
 ### `tlhMaximumSize`
 
@@ -259,6 +323,8 @@ the dynamic compaction triggers that look at heap occupancy. This option works o
 
 : Sets the maximum size of the TLH. The size of the TLH varies from 512 bytes (768 on 64-bit JVMs) to 128 KB, depending on the allocation rate of the thread.
 Larger TLHs can help reduce heap lock contention, but might also reduce heap utilisation and increase heap fragmentation. Typically, when the maximum TLH size is increased, you should also increase the increment size (`-XtlhIncrementSize`) proportionally, so that active threads can reach the maximum requested TLH size more quickly.
+
+: This option can be used with all OpenJ9 GC policies.
 
 ### `verboseFormat`
 
@@ -270,9 +336,19 @@ Larger TLHs can help reduce heap lock contention, but might also reduce heap uti
   |               | `deprecated`   |                                                                                    |
 
 
-    - `default`: The default verbose garbage collection format for OpenJ9. For more information, see [Verbose garbage collection logging](https://www.ibm.com/support/knowledgecenter/SSYKE2_8.0.0/com.ibm.java.vm.80.doc/docs/mm_gc_pd_verbosegc.html).
+    - `default`: The default verbose garbage collection format for OpenJ9. For more information, see [Verbose garbage collection logs](vgclog.md).
     - `deprecated`: The verbose garbage collection format available in the IBM J9 VM V2.4 and earlier.
 
+: This option does not apply to the `metronome` GC policy. The verbose log format for the `metronome` GC policy is equivalent to `-Xgc:verboseFormat=deprecated`.
 
+### `verbosegcCycleTime`
+
+        -Xgc:verbosegcCycleTime=N
+
+: `N` is the time in milliseconds that the summary information should be logged.
+
+    :fontawesome-solid-pencil-alt:{: .note aria-hidden="true"} **Note:** The cycle time does not mean that the summary information is logged precisely at that time, but when the last GC event that meets this time criterion passes.
+
+: This option applies only to the `metronome` GC policy.
 
 <!-- ==== END OF TOPIC ==== xgc.md ==== -->

--- a/docs/xgcpolicy.md
+++ b/docs/xgcpolicy.md
@@ -25,7 +25,7 @@
 # -Xgcpolicy
 
 
-Controls which Garbage Collection (GC) policy is used for your Java&trade; application.
+Controls which garbage collection (GC) policy is used for your Java&trade; application.
 
 ## Syntax
 
@@ -72,9 +72,6 @@ The initial heap size is *Xmx/1024*, rounded down to the nearest power of 2, whe
 
 The following options can also be specified on the command line with `-Xgcpolicy:balanced`:
 
-<!-- - `-Xalwaysclassgc` -->
-<!-- - `-Xclassgc`
-<!-- - `-Xcompactexplicitgc` -->
 - `-Xdisableexcessivegc`
 - `-Xdisableexplicitgc`
 - `-Xenableexcessivegc`
@@ -93,8 +90,6 @@ The following options can also be specified on the command line with `-Xgcpolicy
 - `-Xmnx<size>`
 - `-Xms<size>`
 - `-Xmx<size>`
-<!-- - `-Xnoclassgc` -->
-<!-- - `-Xnocompactexplicitgc` -->
 - `-Xnuma:none`
 - `-Xsoftmx<size>`
 - `-Xsoftrefthreshold<number>`
@@ -132,8 +127,6 @@ The following options are ignored when specified with `-Xgcpolicy:balanced`:
 - `-Xmr<size>`
 - `-Xmrx<size>`
 - `-Xnoloa`
-<!-- - `-Xnopartialcompactgc` (deprecated) -->
-<!-- - `-Xpartialcompactgc` (deprecated) -->
 
 
 ### `optavgpause`
@@ -162,40 +155,16 @@ The following options are ignored when specified with `-Xgcpolicy:balanced`:
 
     To learn more about this policy, how it works, and when to use it, see [Garbage collection: `metronome` policy](gc.md#metronome-policy).
 
-#### `metronome` defaults and options
+#### `metronome` options
 
-`-Xgc:synchronousGCOnOOM | -Xgc:nosynchronousGCOnOOM`
-: GC cycles can occur when the Java heap runs out of memory. If there is no more free space in the heap, using `-Xgc:synchronousGCOnOOM` stops your application while GC operations remove unused objects. If free space runs out again, consider decreasing the target utilization to allow GC operations more time to complete. Setting `-Xgc:nosynchronousGCOnOOM` implies that when heap memory is full your application stops and issues an *out-of-memory* message. The default is `-Xgc:synchronousGCOnOOM`.
+The following options are specific to the `metronome` GC policy:
 
-`-Xclassgc | -Xnoclassgc | -Xalwaysclassgc`
-
-: [`-Xnoclassgc`](xclassgc.md) disables class garbage collection. This option switches off the collection of storage associated with Java classes that are no longer being used by the OpenJ9 VM. The default behavior is [`-Xclassgc`](xclassgc.md), which heuristically decides which GC cycle will attempt to unload classes.
-
-: :fontawesome-solid-pencil-alt:{: .note aria-hidden="true"} **Note:** Disabling class GC is not recommended as this causes unlimited native memory growth, leading to *out-of-memory* errors.
-
-: [`-Xalwaysclassgc`](xalwaysclassgc.md) always performs dynamic class unloading checks during global GC cycles.
-
-`-Xgc:targetPauseTime=N`
-: Sets the GC pause time, where N is the time in milliseconds. When this option is specified, the GC operates with pauses that do not exceed the value specified. If this option is not specified the default pause time is set to 3 milliseconds. For example, running with `-Xgc:targetPauseTime=20` causes the GC to pause for no longer than 20 milliseconds during GC operations.
-
-`-Xgc:targetUtilization=N`
-: Sets the application utilization to `N%`; the GC attempts to use at most (100-N)% of each time interval. Reasonable values are in the range of 50-80%. Applications with low allocation rates might be able to run at 90%. The default is 70%.
-
-    In the following example, the maximum size of the heap is set to 30 MB. The GC attempts to use 25% of each time interval because the target utilization for the application is set to 75%.
-
-        java -Xgcpolicy:metronome -Xmx30m -Xgc:targetUtilization=75 Test
-
-`-Xgc:threads=N`
-: Specifies the number of GC threads to run. The default is the number of processor cores available to the process. The maximum value that you can specify is the number of processors available to the operating system.
-
-`-Xgc:verboseGCCycleTime=N`
-: N is the time in milliseconds that the summary information should be logged.
-
-    :fontawesome-solid-pencil-alt:{: .note aria-hidden="true"} **Note:** The cycle time does not mean that the summary information is logged precisely at that time, but when the last GC event that meets this time criterion passes.
-
-`-Xmx<size>`
-: Specifies the Java heap size. Unlike other GC strategies, the `metronome` policy does not support heap expansion. You can specify only the maximum heap size, not an initial heap size (`-Xms`).
-
+- [`-Xgc:nosynchronousGCOnOOM`](xgc.md#nosynchronousgconoom)
+- [`-Xgc:overrideHiresTimerCheck`](xgc.md#overridehirestimercheck)
+- [`-Xgc:synchronousGCOnOOM`](xgc.md#synchronousgconoom)
+- [`-Xgc:targetPausetime`](xgc.md#targetpausetime)
+- [`-Xgc:targetUtilization`](xgc.md#targetutilization)
+- [`-Xgc:verbosegcCycleTime`](xgc.md#verbosegccycletime)
 
 ### `nogc`
 

--- a/docs/xgcsplitheap.md
+++ b/docs/xgcsplitheap.md
@@ -31,7 +31,7 @@ By default, the VM uses a contiguous Java&trade; heap to store Java objects. How
 
 :fontawesome-solid-exclamation-triangle:{: .warn aria-hidden="true"} **Restrictions:**
 
-- A split heap forces the Garbage Collector to use the `gencon` policy and allocates the new and old areas of the generational Java heap in separate areas of memory. Resizing of the new and old memory areas is disabled.
+- A split heap forces the garbage collector to use the `gencon` policy and allocates the new and old areas of the generational Java heap in separate areas of memory. Resizing of the new and old memory areas is disabled.
 - ![Start of content that applies only to Java 8 (LTS)](cr/java8.png) This option can be used only with Java SE version 8 runtime environments. ![End of content that applies only to Java 8 (LTS)](cr/java_close_lts.png) This option is deprecated in Version 8 and will be removed from future versions.
 
 ## Syntax
@@ -40,13 +40,13 @@ By default, the VM uses a contiguous Java&trade; heap to store Java objects. How
 
 ## Explanation
 
-Use `-Xgc:splitheap` for applications that must run on the 32-bit VM because of 32-bit JNI libraries, a 32-bit operating system, or 32-bit hardware, but need large Java heaps. By using a larger heap, you can allocate more objects before incurring a garbage collection and you can increase the number of live objects that you can use before an `OutOfMemoryError` exception occurs.
+Use `-Xgc:splitheap` for applications that must run on the 32-bit VM because of 32-bit JNI libraries, a 32-bit operating system, or 32-bit hardware, but need large Java heaps. By using a larger heap, you can allocate more objects before incurring a garbage collection (GC) and you can increase the number of live objects that you can use before an `OutOfMemoryError` exception occurs.
 
 With a split heap, the old area is committed to its maximum size (set with `-Xmox`) in a lower region of memory and the new area is committed to its maximum size (set with `-Xmnx`) in a higher region of memory.
 
 This option is not recommended if your application works in the any of the following ways:
 
-- Performs poorly under the gencon garbage collection policy.
+- Performs poorly under the `gencon` GC policy.
 - Loads a very large number of classes.
 - Uses large amounts of native system memory in JNI libraries; the increased size Java heap might reserve too much of the application's address space.
 

--- a/docs/xgcthreads.md
+++ b/docs/xgcthreads.md
@@ -25,7 +25,7 @@
 # -Xgcthreads
 
 
-Sets the number of threads that the garbage collector uses for parallel operations. 
+Sets the number of threads that the garbage collector uses for parallel operations.
 
 :fontawesome-solid-pencil-alt:{: .note aria-hidden="true"} **Notes:**
 
@@ -40,6 +40,8 @@ This option enforces a fixed thread count and cannot be used with the [`-XX:+Ada
 The total number of GC threads is composed of one application thread with the remainder being dedicated GC threads. By default, the number is set to `n-1`, where `n` is the number of reported CPUs, up to a maximum of 64. Where SMT or hyperthreading is in place, the number of reported CPUs is larger than the number of physical CPUs. Likewise, where virtualization is in place, the number of reported CPUs is the number of virtual CPUs assigned to the operating system. To set it to a different number, for example 4, use `-Xgcthreads4`. The minimum valid value is 1, which disables parallel operations, at the cost of performance. No advantage is gained if you increase the number of threads to more than the default setting.
 
 On systems running multiple VMs or in LPAR environments where multiple VMs can share the same physical CPUs, you might want to restrict the number of GC threads used by each VM. The restriction helps prevent the total number of parallel operation GC threads for all VMs exceeding the number of physical CPUs present, when multiple VMs perform garbage collection at the same time.
+
+This option is directly mapped to the HotSpot option [`-XX:ParallelGCThreads`](xxparallelgcthreads.md) and can be used with all OpenJ9 GC policies.
 
 
 <!-- ==== END OF TOPIC ==== xgcthreads.md ==== -->

--- a/docs/xgcworkpackets.md
+++ b/docs/xgcworkpackets.md
@@ -22,7 +22,7 @@
 * Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
 -->
 
-# -Xgcworkpackets 
+# -Xgcworkpackets
 
 
 Specifies the total number of work packets available in the global collector.
@@ -35,7 +35,8 @@ Specifies the total number of work packets available in the global collector.
 
 If you do not specify a value, the collector allocates a number of packets based on the maximum heap size.
 
+This option can be used with all OpenJ9 GC policies.
+
 
 
 <!-- ==== END OF TOPIC ==== xgcworkpackets.md ==== -->
-

--- a/docs/xloa.md
+++ b/docs/xloa.md
@@ -24,7 +24,7 @@
 
 # -Xloa / -Xnoloa
 
-This option enables or prevents allocation of a large object area (LOA) during garbage collection.
+This option enables or prevents the allocation of a large object area (LOA) during garbage collection (GC).
 
 ## Syntax
 
@@ -45,7 +45,7 @@ The LOA is an area of the tenure area of the heap set used solely to satisfy all
 
 As objects are allocated and freed, the heap can become fragmented in such a way that allocation can be met only by time-consuming compactions. This problem is more pronounced if an application allocates large objects. In an attempt to alleviate this problem, the LOA is allocated. A large object in this context is considered to be any object 64 KB or greater in size. Allocations for new TLH objects are not considered to be large objects.
 
-:fontawesome-solid-pencil-alt:{: .note aria-hidden="true"} **Note:** The Balanced Garbage Collection policy does not use the LOA. Therefore, when specifying -`Xgcpolicy:balanced`, any LOA options passed on the command line are ignored. The policy addresses the issues of LOA by reorganizing object layout with the VM to reduce heap fragmentation and compaction requirements. 
+This option is not supported with the balanced GC policy (`-Xgcpolicy:balanced`) or metronome GC policy (`-Xgcpolicy:metronome`), which do not use an LOA. Any LOA options passed on the command line are ignored. These policies address the issues that are solved by an LOA by reorganizing object layout with the VM to reduce heap fragmentation and compaction requirements.
 
 ## See also
 

--- a/docs/xloaminimum.md
+++ b/docs/xloaminimum.md
@@ -22,11 +22,11 @@
 * Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
 -->
 
-# -Xloainitial / -Xloaminimum / -Xloamaximum 
+# -Xloainitial / -Xloaminimum / -Xloamaximum
 
-Specifies the initial, minimum, and maximum proportion of the current tenure space allocated to the large object area (LOA). 
+Specifies the initial, minimum, and maximum proportion of the current tenure space allocated to the large object area (LOA).
 
-The LOA does not shrink to less than the minimum value. 
+The LOA does not shrink to less than the minimum value.
 
 ## Syntax
 
@@ -40,6 +40,7 @@ The LOA does not shrink to less than the minimum value.
 
 - [-Xloa / Xnoloa](xloa.md)
 
+This option is not supported with the balanced GC policy (`-Xgcpolicy:balanced`) or metronome GC policy (`-Xgcpolicy:metronome`), which do not use an LOA.
 
 <!-- ==== END OF TOPIC ==== xloainitial.md ==== -->
 <!-- ==== END OF TOPIC ==== xloaminimum.md ==== -->

--- a/docs/xmca.md
+++ b/docs/xmca.md
@@ -27,7 +27,7 @@
 
 Sets the expansion step for the memory allocated to store the RAM (`-Xmca`) and ROM (`-Xmco`) portions of loaded classes.
 
-Each time more memory is required to store classes in RAM or ROM, the allocated memory is increased by the amount set. 
+Each time more memory is required to store classes in RAM or ROM, the allocated memory is increased by the amount set.
 
 If the expansion step size you choose is too large, `OutOfMemoryError` is reported. The exact value of a *"too large"* expansion step size varies according to the platform and the specific machine configuration.
 
@@ -42,7 +42,11 @@ You can use the `-verbose:sizes` option to find out the value that is being used
 
 See [Using -X command-line options](x_jvm_commands.md) for more information about the `<size>` parameter.
 
+This option cannot be used with the metronome GC policy (`-Xgcpolicy:metronome`) because the heap is always fully expanded.
+
+## See also
+
+- [Heap expansion and contraction](allocation.md#expansion-and-contraction)
 
 <!-- ==== END OF TOPIC ==== xmca.md ==== -->
 <!-- ==== END OF TOPIC ==== xmco.md ==== -->
-

--- a/docs/xmine.md
+++ b/docs/xmine.md
@@ -45,10 +45,11 @@ If heap expansion is required:
 - `-Xmine` forces the expansion to be at least the specified value. For example, `-Xmine10M` sets the expansion size to a minimum of 10 MB.  
 - `-Xmaxe` limits the expansion to the specified value. For example `-Xmaxe50M` prevents expansion by more than 50 MB. (`-Xmaxe0` allows unlimited expansion.)
 
+For the `gencon` GC policy, the values apply only to the tenure part of the heap. For the `balanced`, `optthruput`, and `optavgpause` GC policies, these values apply to the whole heap. This option cannot be used with the metronome GC policy (`-Xgcpolicy:metronome`) because the heap is always fully expanded.
+
 ## See also
 
-- [Heap shrinkage](https://www.ibm.com/support/knowledgecenter/SSYKE2_8.0.0/com.ibm.java.vm.80.doc/docs/mm_gc_heapshrinkage.html)
-- [Heap expansion](https://www.ibm.com/support/knowledgecenter/SSYKE2_8.0.0/com.ibm.java.vm.80.doc/docs/mm_gc_heapexpansion.html)
+- [Heap expansion and contraction](allocation.md#expansion-and-contraction)
 
 
 <!-- ==== END OF TOPIC ==== xmine.md ==== -->

--- a/docs/xminf.md
+++ b/docs/xminf.md
@@ -38,13 +38,14 @@ If the free space is above or below these limits, the OpenJ9 VM attempts to adju
 
 The value range is 0.0 - 1.0.
 
-- For the `gencon` GC policy, the values apply only to the Tenure part of the heap and only at global GC points.
+- For the `gencon` GC policy, the values apply only to the tenure part of the heap and only at global GC points.
 - For the `optthruput` and `optavgpause` GC policies, these values apply to the whole heap at every GC point.
+
+This option cannot be used with the metronome GC policy (`-Xgcpolicy:metronome`) because the heap is always fully expanded.
 
 ## See also
 
-- [Heap shrinkage](https://www.ibm.com/support/knowledgecenter/SSYKE2_8.0.0/com.ibm.java.vm.80.doc/docs/mm_gc_heapshrinkage.html)
-- [Heap expansion](https://www.ibm.com/support/knowledgecenter/SSYKE2_8.0.0/com.ibm.java.vm.80.doc/docs/mm_gc_heapexpansion.html)
+- [Heap expansion and contraction](allocation.md#expansion-and-contraction)
 
 
 <!-- ==== END OF TOPIC ==== xminf.md ==== -->

--- a/docs/xmint.md
+++ b/docs/xmint.md
@@ -28,7 +28,7 @@
 Sets the minimum and maximum proportion of time to spend in the garbage collection (GC) process as a percentage of the overall running time that included the last three GC runs.
 
 - If the percentage of time drops to less than the minimum, the OpenJ9 VM tries to shrink the heap.
-- If the percentage of time exceeds the maximum, the OpenJ9 VM tries to expand the heap.
+- If the percentage of time exceeds the maximum, the VM tries to expand the heap.
 
 :fontawesome-solid-exclamation-triangle:{: .warn aria-hidden="true"} **Restrictions:**
 
@@ -42,6 +42,11 @@ Sets the minimum and maximum proportion of time to spend in the garbage collecti
 |`-Xmint<value>` | Set minimum time in GC | 5       |
 |`-Xmaxt<value>` | Set maximum time in GC | 13      |
 
+For the `gencon` GC policy, the values apply only to the tenure part of the heap. For the `balanced`, `optthruput`, and `optavgpause` GC policies, these values apply to the whole heap. This option cannot be used with the metronome GC policy (`-Xgcpolicy:metronome`) because the heap is always fully expanded.
+
+## See also
+
+- [Heap expansion and contraction](allocation.md#expansion-and-contraction)
 
 <!-- ==== END OF TOPIC ==== xmint.md ==== -->
 <!-- ==== END OF TOPIC ==== xmaxt.md ==== -->

--- a/docs/xmn.md
+++ b/docs/xmn.md
@@ -25,9 +25,7 @@
 # -Xmn / -Xmns / -Xmnx
 
 
-Sets the initial and maximum size of the new area when using `-Xgcpolicy:gencon`.
-
-If the scavenger is disabled, this option is ignored.
+Sets the initial and maximum size of the nursery area when using the [`gencon` garbage collection (GC) policy](gc.md#gencon-policy-default) (`-Xgcpolicy:gencon`). These options are ignored if they are used with any other GC policy.
 
 You can use the `-verbose:sizes` option to find out the value that is being used by the VM.
 
@@ -41,11 +39,16 @@ You can use the `-verbose:sizes` option to find out the value that is being used
 
 See [Using -X command-line options](x_jvm_commands.md) for more information about the `<size>` parameter.
 
-:fontawesome-solid-exclamation-triangle:{: .warn aria-hidden="true"} **Restriction:** If you try to set `-Xmn` with either `-Xmns` or `-Xmnx`, the VM does not start, returning an error. 
+:fontawesome-solid-exclamation-triangle:{: .warn aria-hidden="true"} **Restriction:** If you try to set `-Xmn` with either `-Xmns` or `-Xmnx`, the VM does not start, returning an error.
 
+To set the size of the tenure area of the heap, see [`-Xmo/-Xmos/-Xmox`](xmo.md).
 
+## See also
+
+- [`gencon` policy (default)](gc.md#gencon-policy-default)
+- [`-Xmo/-Xmos/-Xmox`](xmo.md)
+- [`-Xms`/`-Xmx`](xms.md)
 
 <!-- ==== END OF TOPIC ==== xmn.md ==== -->
 <!-- ==== END OF TOPIC ==== xmns.md ==== -->
 <!-- ==== END OF TOPIC ==== xmnx.md ==== -->
-

--- a/docs/xmo.md
+++ b/docs/xmo.md
@@ -22,30 +22,32 @@
 * Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
 -->
 
-# -Xmo / -Xmoi / -Xmos / -Xmox
+# -Xmo / -Xmos / -Xmox
 
-
-Sets the size and behavior of the old (tenure) heap when using `-Xgcpolicy:gencon`.
+Sets the size of the tenure area of the heap for the `gencon` garbage collection (GC) policy.
 
 You can use the `-verbose:sizes` option to find out the values that the VM is currently using.
 
 ## Syntax
 
-| Setting       | Effect                                         | Default                   |
-|---------------|------------------------------------------------|---------------------------|
-| `-Xmo<size>`  | Equivalent to setting both `-Xmos` and `-Xmox` | not set                   |
-| `-Xmoi<size>` | Set increment size of old (tenure) heap        | See **Note**              |
-| `-Xmos<size>` | Set initial size of old (tenure) heap          | 75% of [`-Xms`](xms.md)   |
-| `-Xmox<size>` | Set maximum size of old (tenure) heap          | Same as [`-Xmx`](xms.md)  |
-
-:fontawesome-solid-pencil-alt:{: .note aria-hidden="true"} **Note:** By default, the increment size (`-Xmoi`) is calculated on the expansion size, set by [`-Xmine`](xmine.md) and [`-Xminf`](xminf.md).  If you set `-Xmoi` to zero, no expansion is allowed.
+| Setting       | Effect                                            | Default                   |
+|---------------|---------------------------------------------------|---------------------------|
+| `-Xmo<size>`  | Equivalent to setting both `-Xmos` and `-Xmox`    | not set                   |            |
+| `-Xmos<size>` | Set initial size of the tenure area of the heap   | 75% of [`-Xms`](xms.md)   |
+| `-Xmox<size>` | Set maximum size of the tenure area of the heap   | Same as [`-Xmx`](xms.md)  |
 
 See [Using -X command-line options](x_jvm_commands.md) for more information about the `<size>` parameter.
 
-:fontawesome-solid-exclamation-triangle:{: .warn aria-hidden="true"} **Restriction:** If you try to set `-Xmo` with either `-Xmos` or `-Xmox`, the VM does not start, returning an error. 
+:fontawesome-solid-exclamation-triangle:{: .warn aria-hidden="true"} **Restriction:** If you try to set `-Xmo` with either `-Xmos` or `-Xmox`, the VM does not start, returning an error.
 
+To set the size of the nursery area of the heap, see [`-Xmn/-Xmns/-Xmnx`](xmn.md).
+
+## See also
+
+- [`gencon` policy (default)](gc.md#gencon-policy-default)
+- [`-Xmn/-Xmns/-Xmnx`](xmn.md)
+- [`-Xms`/`-Xmx`](xms.md)
 
 <!-- ==== END OF TOPIC ==== xmo.md ==== -->
-<!-- ==== END OF TOPIC ==== xmoi.md ==== -->
 <!-- ==== END OF TOPIC ==== xmos.md ==== -->
 <!-- ==== END OF TOPIC ==== xmox.md ==== -->

--- a/docs/xmoi.md
+++ b/docs/xmoi.md
@@ -22,21 +22,31 @@
 * Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
 -->
 
-# -Xmr / &nbsp; -Xmrx
+# -Xmoi
 
+Sets the heap expansion allocation increment.
 
-Sets the initial and maximum size of the the garbage collection (GC) *remembered set* in the `gencon` GC policy. The remembered set is a list of objects in the tenure area of the heap that have references to objects in the new area.
+You can use the `-verbose:sizes` option to find out the values that the VM is currently using.
 
 ## Syntax
 
-| Setting       | Effect            | Default                   |
-|---------------|-------------------|---------------------------|
-| `-Xmr<size>`  | Set initial size  | 16 K                      |
-| `-Xmrx<size>` | Set maximium size |                           |
+| Setting       | Effect                                            | Default                   |
+|---------------|---------------------------------------------------|---------------------------|
+| `-Xmoi<size>` | Sets the heap expansion allocation increment      | See **Notes**              |
+
+
+:fontawesome-solid-pencil-alt:{: .note aria-hidden="true"} **Notes:**
+
+- By default, the increment size (`-Xmoi`) is calculated on the expansion size, set by [`-Xmine`](xmine.md) and [`-Xminf`](xminf.md).  If you set `-Xmoi` to zero, no expansion is allowed.
+- For the `gencon` GC policy, the expansion increment applies to the tenure area of the heap.  
+
+This option is not supported for the `metronome` GC policy, because the heap is always fully expanded.
 
 See [Using -X command-line options](x_jvm_commands.md) for more information about the `<size>` parameter.
 
-This option applies only to the `gencon` GC policy.
+## See also
 
-<!-- ==== END OF TOPIC ==== xmr.md ==== -->
-<!-- ==== END OF TOPIC ==== xmrx.md ==== -->
+- [Heap expansion and contraction](allocation.md#expansion-and-contraction)
+
+
+<!-- ==== END OF TOPIC ==== xmoi.md ==== -->

--- a/docs/xms.md
+++ b/docs/xms.md
@@ -29,14 +29,15 @@ These Oracle&reg; HotSpot&trade; options set the initial/minimum Java&trade; hea
 
 :fontawesome-solid-pencil-alt:{: .note aria-hidden="true"} **Notes:**
 
-- If you set `-Xms` &gt; `-Xmx`, the OpenJ9 VM fails with the message `-Xms too large for -Xmx`.
-- If you exceed the limit set by the `-Xmx` option, the OpenJ9 VM generates an `OutofMemoryError`.
+- If you set `-Xms` &gt; `-Xmx`, the VM fails with the message `-Xms too large for -Xmx`.
+- If you exceed the limit set by the `-Xmx` option, the VM generates an `OutofMemoryError`.
 - If you set a value for `-Xms`, the [`-XX:InitialRAMPercentage`](xxinitialrampercentage.md) option is ignored.
 - If you set a value for `-Xmx`, the [`-XX:MaxRAMPercentage`](xxinitialrampercentage.md) option is ignored.
 
-You can also use the [`-Xmo`](xmo.md) option (not supported by the balanced garbage collection policy):  
-If the scavenger is enabled, `-Xms` &ge; `-Xmn` + `-Xmo`  
-If the scavenger is disabled, `-Xms` &ge; `-Xmo`  
+For the `gencon` GC policy, you can also use the [`-Xmo`](xmo.md) option:
+
+- If the scavenger is enabled, `-Xms` &ge; `-Xmn` + `-Xmo`  
+- If the scavenger is disabled, `-Xms` &ge; `-Xmo`  
 
 ## Syntax
 
@@ -47,6 +48,8 @@ If the scavenger is disabled, `-Xms` &ge; `-Xmo`
 
 See [Using -X command-line options](x_jvm_commands.md) for more information about the `<size>` parameter.  
 See [Default settings for the OpenJ9 VM](openj9_defaults.md) for more about default values.
+
+The `-Xmx` option can be used with all OpenJ9 GC policies. However, the `-Xms` option can be used with all GC policies except for the `metronome` GC policy because the heap is always fully expanded.
 
 ## Examples
 

--- a/docs/xsoftmx.md
+++ b/docs/xsoftmx.md
@@ -24,7 +24,7 @@
 
 # -Xsoftmx
 
-This option sets a "soft" maximum limit for the initial size of the Java&trade; heap.
+This option sets a "soft" maximum limit for the Java&trade; heap.
 
 ## Syntax
 
@@ -32,7 +32,9 @@ This option sets a "soft" maximum limit for the initial size of the Java&trade; 
 
 ## Explanation
 
-Use the [`-Xmx`](xms.md) option to set a "hard" limit for the maximum size of the heap. By default, `-Xsoftmx` is set to the same value as `-Xmx`. The value of `-Xms` must be less than, or equal to, the value of `-Xsoftmx`. See the introduction to this topic for more information about specifying *&lt;size&gt;* parameters.
+Use the [`-Xmx`](xms.md) option to set a "hard" limit for the maximum size of the heap. By default, `-Xsoftmx` is set to the same value as `-Xmx`. The value of `-Xms` must be less than, or equal to, the value of `-Xsoftmx`.
+
+See [Using -X command-line options](x_jvm_commands.md) for more information about the `<size>` parameter.
 
 You can set this option on the command line, then modify it at run time by using the `MemoryMXBean.setMaxHeapSize()` method in the `com.ibm.lang.management` API. By using this API, Java applications can dynamically monitor and adjust the heap size as required. This function can be useful in virtualized or cloud environments, for example, where the available memory might change dynamically to meet business needs. When you use the API, you must specify the value in bytes, such as `2147483648` instead of `2g`.
 
@@ -48,12 +50,9 @@ When the heap shrinks, the garbage collector might release memory. The ability o
 
 :fontawesome-solid-pencil-alt:{: .note aria-hidden="true"} **Notes:**
 
-- When using `-Xgcpolicy:gencon`, `-Xsoftmx` applies only to the non-nursery portion of the heap. In some cases the heap grows to greater than the `-Xsoftmx` value because the nursery portion grows, making the heap size exceed the limit that is set. See `-Xmn` for limiting the nursery size.
-
-- When using `-Xgcpolicy:metronome`, `-Xsoftmx` is ignored because the Metronome garbage collector does not support contraction or expansion of the heap.
-
-- There might be little benefit in reducing the `-Xsoftmx` value when the Java heap is using large pages. Large pages are pinned in memory and are not reclaimed by the operating system, with the exception of 1M pageable pages on z/OS&reg;. On certain platforms and processors the VM starts with large pages enabled by default for the Java heap when the operating system is configured to provide large pages.
-For more information, see [Configuring large page memory allocation](configuring.md#configuring-large-page-memory-allocation). A future version of the Java virtual machine might provide a hint to the operating system when large pages are no longer in use.
+- When using `-Xgcpolicy:gencon`, `-Xsoftmx` applies only to the tenure area of the heap. In some cases the heap grows to greater than the `-Xsoftmx` value because the nursery portion grows, making the heap size exceed the limit that is set. See [`-Xmn`](xmn.md) for limiting the nursery size.
+- This option is ignored if used with the metronome GC policy (`-Xgcpolicy:metronome`) because the heap is always fully expanded.
+- There might be little benefit in reducing the `-Xsoftmx` value when the Java heap is using large pages. Large pages are pinned in memory and are not reclaimed by the operating system, with the exception of 1M pageable pages on z/OS&reg;. On certain platforms and processors the VM starts with large pages enabled by default for the Java heap when the operating system is configured to provide large pages. For more information, see [Configuring large page memory allocation](configuring.md#configuring-large-page-memory-allocation). A future version of the Java virtual machine might provide a hint to the operating system when large pages are no longer in use.
 
 
 

--- a/docs/xsoftrefthreshold.md
+++ b/docs/xsoftrefthreshold.md
@@ -22,10 +22,10 @@
 * Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
 -->
 
-# -Xsoftrefthreshold 
+# -Xsoftrefthreshold
 
 
-Sets the value used by the garbage collector to determine the number of garbage collections after which a soft reference is cleared if its referent has not been marked.
+Sets the value used by the garbage collector to determine the number of garbage collection (GC) cycles after which a soft reference is cleared if its referent has not been marked.
 
 ## Syntax
 
@@ -35,12 +35,13 @@ Sets the value used by the garbage collector to determine the number of garbage 
 
 The default value is 32.
 
+This option can be used with all OpenJ9 GC policies.
+
 ## Explanation
 
-A soft reference (where its referent is not marked) is cleared after a number of garbage collection cycles calculated as: `<value>` \* (proportion of free heap space)
+A soft reference (where its referent is not marked) is cleared after a number of GC cycles, which is calculated as: `<value>` \* (proportion of free heap space)
 
-For example, if `-Xsoftrefthreshold` is set to 32, and the heap is 25% free, soft references are cleared after 8 garbage collection cycles.
+For example, if `-Xsoftrefthreshold` is set to 32, and the heap is 25% free, soft references are cleared after 8 GC cycles.
 
 
 <!-- ==== END OF TOPIC ==== xsoftrefthreshold.md ==== -->
-

--- a/docs/xtlhprefetch.md
+++ b/docs/xtlhprefetch.md
@@ -32,7 +32,7 @@ Speculatively prefetches bytes in the thread local heap (TLH) ahead of the curre
 
         -XtlhPrefetch
 
-
+This option can be used with all OpenJ9 GC policies.
 
 
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -252,7 +252,7 @@ nav:
             - "-Xfuture"                                                         : xfuture.md
             - "-Xgc"                                                             : xgc.md
             - "-Xgc:splitheap"                                                   : xgcsplitheap.md
-            - "-Xgcmaxthreads"                                                   : xgcmaxthreads.md            
+            - "-Xgcmaxthreads"                                                   : xgcmaxthreads.md
             - "-Xgcpolicy"                                                       : xgcpolicy.md
             - "-Xgcthreads"                                                      : xgcthreads.md
             - "-Xgcworkpackets"                                                  : xgcworkpackets.md
@@ -284,7 +284,7 @@ nav:
             - "-Xmns"                                                            : xmn.md                             # redirect
             - "-Xmnx"                                                            : xmn.md                             # redirect
             - "-Xmo"                                                             : xmo.md
-            - "-Xmoi"                                                            : xmo.md                             # redirect
+            - "-Xmoi"                                                            : xmoi.md
             - "-Xmos"                                                            : xmo.md                             # redirect
             - "-Xmox"                                                            : xmo.md                             # redirect
             - "-Xmr"                                                             : xmr.md


### PR DESCRIPTION
- Add clarity for GC options regarding which policies can and can't use them.
- Move a few metronome `-Xgc` options from `-Xgcpolicy` to their correct location.
- Some tidying up/editing improvements.

Signed-off-by: SueChaplain <Sue_chaplain@uk.ibm.com>