### PR TITLE
Updates for Material theme 7.1.4

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -50,6 +50,7 @@ The user documentation is authored in Markdown and built into HTML using [Mkdocs
     - [- Which OpenJDK version?](#which-openjdk-version)
     - [- Trademarks](#trademarks)
     - [- Using images](#using-images)
+    - [- Referencing non-Markdown pages](#referencing-non-markdown-pages)
     - [- Accessibility](#accessibility)
     - [Testing your changes locally](#testing-your-changes-locally)
     - [Submitting a contribution](#submitting-a-contribution)
@@ -239,6 +240,16 @@ Font-awesome icons are also used in option tables to indicate defaults. The foll
 Note that these require an extra `<span>`, which is used by screen readers.
 
 For examples that embed Java version icons such as ![Java 8 icon](docs/cr/java8.png) and ![Java 14 and later icon](docs/cr/java14plus.png), see [Which OpenJDK version?](#which-openjdk-version?).
+
+### Referencing non-Markdown pages
+
+The user documentation has two builds, one for use in the web site and a special build for offline use. The offline build uses the Mkdocs `use_directory_urls: false` configuration setting, which alters the layout of the site and automatically adjusts relative urls between Markdown files. However, relative urls to non-Markdown pages, which are copied as-is into the `/site` directory, are not adjusted.
+
+If you need to reference a non-Markdown page from a Markdown file use the variable `config.use_directory_urls` provided by `mkdocs-macros` plugin. For example in the [OpenJ9 JDK 11 API documentation](docs/api-jdk11.md), the `iframe` element uses this technique in the `src` attribute:
+
+```
+{% if config.use_directory_urls %}../{% endif %}api/jdk11/index.html?view=embed
+```
 
 ### Accessibility
 

--- a/JenkinsFile_build_doc.groovy
+++ b/JenkinsFile_build_doc.groovy
@@ -152,6 +152,7 @@ timeout(time: 6, unit: 'HOURS') {
                                 git clean -ffxd
                                 git status
                                 sed -i "s|site_dir: 'site'|use_directory_urls: false\\nsite_dir: 'site'|" mkdocs.yml
+                                sed -i "/- search/d" mkdocs.yml
                                 mkdocs build -v
                                 cd site
                                 zip -r ${ZIP_FILENAME} *

--- a/buildenv/requirements.in
+++ b/buildenv/requirements.in
@@ -26,3 +26,4 @@
 # requirements.in
 mkdocs
 mkdocs-material
+mkdocs-macros-plugin

--- a/buildenv/requirements.txt
+++ b/buildenv/requirements.txt
@@ -23,24 +23,73 @@
 #
 # Mkdocs build dependencies pinned
 #
-click==7.1.2              # via mkdocs, nltk
-future==0.18.2            # via lunr
-importlib-metadata==2.1.1  # via markdown
-jinja2==2.11.3            # via mkdocs
-joblib==0.14.1            # via nltk
-livereload==2.6.3         # via mkdocs
-lunr[languages]==0.5.8    # via mkdocs
-markdown==3.2.2           # via mkdocs, mkdocs-material, pymdown-extensions
-markupsafe==1.1.1         # via jinja2
-mkdocs-material-extensions==1.0.1  # via mkdocs-material
-mkdocs-material==7.0.3
+click==8.0.0
+    # via
+    #   mkdocs
+    #   nltk
+future==0.18.2
+    # via lunr
+importlib-metadata==4.0.1
+    # via markdown
+jinja2==3.0.0
+    # via
+    #   mkdocs
+    #   mkdocs-macros-plugin
+joblib==1.0.1
+    # via nltk
+livereload==2.6.3
+    # via mkdocs
+lunr[languages]==0.5.8
+    # via mkdocs
+markdown==3.3.4
+    # via
+    #   mkdocs
+    #   mkdocs-material
+    #   pymdown-extensions
+markupsafe==2.0.0
+    # via jinja2
+mkdocs-macros-plugin==0.5.5
+    # via -r requirements.in
+mkdocs-material-extensions==1.0.1
+    # via mkdocs-material
+mkdocs-material==7.1.4
+    # via
+    #   -r requirements.in
+    #   mkdocs-macros-plugin
+    #   mkdocs-material-extensions
 mkdocs==1.1.2
-nltk==3.5                 # via lunr
-pygments==2.8.0           # via mkdocs-material
-pymdown-extensions==8.0.1  # via mkdocs-material
-pyyaml==5.3.1             # via mkdocs
-regex==2020.11.13         # via nltk
-six==1.15.0               # via livereload, lunr
-tornado==6.1              # via livereload, mkdocs
-tqdm==4.58.0              # via nltk
-zipp==1.2.0               # via importlib-metadata
+    # via
+    #   -r requirements.in
+    #   mkdocs-macros-plugin
+    #   mkdocs-material
+nltk==3.6.2
+    # via lunr
+pygments==2.9.0
+    # via mkdocs-material
+pymdown-extensions==8.2
+    # via mkdocs-material
+python-dateutil==2.8.1
+    # via mkdocs-macros-plugin
+pyyaml==5.4.1
+    # via
+    #   mkdocs
+    #   mkdocs-macros-plugin
+regex==2021.4.4
+    # via nltk
+six==1.16.0
+    # via
+    #   livereload
+    #   lunr
+    #   python-dateutil
+termcolor==1.1.0
+    # via mkdocs-macros-plugin
+tornado==6.1
+    # via
+    #   livereload
+    #   mkdocs
+tqdm==4.60.0
+    # via nltk
+typing-extensions==3.10.0.0
+    # via importlib-metadata
+zipp==3.4.1
+    # via importlib-metadata

--- a/docs/api-conditionhandling.md
+++ b/docs/api-conditionhandling.md
@@ -25,6 +25,6 @@
 # Condition Handling API documentation
 
 <div id="api" data-role="content">
-	<iframe src="../api/jdk8/platform/zosconditionhandling/index.html?view=embed" title="API viewer" name="apiframe" allow="autoplay *; fullscreen *; encrypted-media *" allowfullscreen="true" webkitallowfullscreen="true" mozallowfullscreen="true" style="min-height:80vh; width: 100%;">
+	<iframe src="{% if config.use_directory_urls %}../{% endif %}api/jdk8/platform/zosconditionhandling/index.html?view=embed" title="API viewer" name="apiframe" allow="autoplay *; fullscreen *; encrypted-media *" allowfullscreen="true" webkitallowfullscreen="true" mozallowfullscreen="true" style="min-height:80vh; width: 100%;">
 	</iframe>
 </div>

--- a/docs/api-cuda.md
+++ b/docs/api-cuda.md
@@ -25,6 +25,6 @@
 # CUDA4J API documentation
 
 <div id="api" data-role="content">
-	<iframe src="../api/jdk8/platform/cuda/index.html?view=embed" title="API viewer" name="apiframe" allow="autoplay *; fullscreen *; encrypted-media *" allowfullscreen="true" webkitallowfullscreen="true" mozallowfullscreen="true" style="min-height:80vh; width: 100%;">
+	<iframe src="{% if config.use_directory_urls %}../{% endif %}api/jdk8/platform/cuda/index.html?view=embed" title="API viewer" name="apiframe" allow="autoplay *; fullscreen *; encrypted-media *" allowfullscreen="true" webkitallowfullscreen="true" mozallowfullscreen="true" style="min-height:80vh; width: 100%;">
 	</iframe>
 </div>

--- a/docs/api-daa.md
+++ b/docs/api-daa.md
@@ -25,6 +25,6 @@
 # Data access acceleration API documentation
 
 <div id="api" data-role="content">
-	<iframe src="../api/jdk8/platform/dataaccess/index.html?view=embed" title="API viewer" name="apiframe" allow="autoplay *; fullscreen *; encrypted-media *" allowfullscreen="true" webkitallowfullscreen="true" mozallowfullscreen="true" style="min-height:80vh; width: 100%;">
+	<iframe src="{% if config.use_directory_urls %}../{% endif %}api/jdk8/platform/dataaccess/index.html?view=embed" title="API viewer" name="apiframe" allow="autoplay *; fullscreen *; encrypted-media *" allowfullscreen="true" webkitallowfullscreen="true" mozallowfullscreen="true" style="min-height:80vh; width: 100%;">
 	</iframe>
 </div>

--- a/docs/api-dtfj.md
+++ b/docs/api-dtfj.md
@@ -25,6 +25,6 @@
 # DTFJ API documentation
 
 <div id="api" data-role="content">
-	<iframe src="../api/jdk8/platform/dtfj/index.html?view=embed" title="API viewer" name="apiframe" allow="autoplay *; fullscreen *; encrypted-media *" allowfullscreen="true" webkitallowfullscreen="true" mozallowfullscreen="true" style="min-height:80vh; width: 100%;">
+	<iframe src="{% if config.use_directory_urls %}../{% endif %}api/jdk8/platform/dtfj/index.html?view=embed" title="API viewer" name="apiframe" allow="autoplay *; fullscreen *; encrypted-media *" allowfullscreen="true" webkitallowfullscreen="true" mozallowfullscreen="true" style="min-height:80vh; width: 100%;">
 	</iframe>
 </div>

--- a/docs/api-gpu.md
+++ b/docs/api-gpu.md
@@ -25,7 +25,7 @@
 # GPU API documentation
 
 <div id="api" data-role="content">
-	<iframe src="../api/jdk8/platform/gpu/index.html?view=embed" title="API viewer" name="apiframe" allow="autoplay *; fullscreen *; encrypted-media *" allowfullscreen="true" webkitallowfullscreen="true" mozallowfullscreen="true" style="min-height:80vh; width: 100%;">
+	<iframe src="{% if config.use_directory_urls %}../{% endif %}api/jdk8/platform/gpu/index.html?view=embed" title="API viewer" name="apiframe" allow="autoplay *; fullscreen *; encrypted-media *" allowfullscreen="true" webkitallowfullscreen="true" mozallowfullscreen="true" style="min-height:80vh; width: 100%;">
 	</iframe>
 </div>
 

--- a/docs/api-jdk11.md
+++ b/docs/api-jdk11.md
@@ -25,6 +25,6 @@
 # OpenJ9 JDK 11 API documentation
 
 <div id="api" data-role="content">
-	<iframe src="../api/jdk11/index.html?view=embed" title="API viewer" name="classFrame" allow="autoplay *; fullscreen *; encrypted-media *" allowfullscreen="true" webkitallowfullscreen="true" mozallowfullscreen="true" style="min-height:80vh; width: 100%;">
+	<iframe src="{% if config.use_directory_urls %}../{% endif %}api/jdk11/index.html?view=embed" title="API viewer" name="classFrame" allow="autoplay *; fullscreen *; encrypted-media *" allowfullscreen="true" webkitallowfullscreen="true" mozallowfullscreen="true" style="min-height:80vh; width: 100%;">
 	</iframe>
 </div>

--- a/docs/api-jdk16.md
+++ b/docs/api-jdk16.md
@@ -25,6 +25,6 @@
 # OpenJ9 JDK 16 API documentation
 
 <div id="api" data-role="content">
-	<iframe src="../api/jdk16/index.html?view=embed" title="API viewer" name="classFrame" allow="autoplay *; fullscreen *; encrypted-media *" allowfullscreen="true" webkitallowfullscreen="true" mozallowfullscreen="true" style="min-height:80vh; width: 100%;">
+	<iframe src="{% if config.use_directory_urls %}../{% endif %}api/jdk16/index.html?view=embed" title="API viewer" name="classFrame" allow="autoplay *; fullscreen *; encrypted-media *" allowfullscreen="true" webkitallowfullscreen="true" mozallowfullscreen="true" style="min-height:80vh; width: 100%;">
 	</iframe>
 </div>

--- a/docs/api-jvm.md
+++ b/docs/api-jvm.md
@@ -25,7 +25,7 @@
 # JVM diagnostic utilities API documentation
 
 <div id="api" data-role="content">
-	<iframe src="../api/jdk8/platform/jvm/index.html?view=embed" title="API viewer" name="apiframe" allow="autoplay *; fullscreen *; encrypted-media *" allowfullscreen="true" webkitallowfullscreen="true" mozallowfullscreen="true" style="min-height:80vh; width: 100%;">
+	<iframe src="{% if config.use_directory_urls %}../{% endif %}api/jdk8/platform/jvm/index.html?view=embed" title="API viewer" name="apiframe" allow="autoplay *; fullscreen *; encrypted-media *" allowfullscreen="true" webkitallowfullscreen="true" mozallowfullscreen="true" style="min-height:80vh; width: 100%;">
 	</iframe>
 </div>
 

--- a/docs/api-langmgmt.md
+++ b/docs/api-langmgmt.md
@@ -25,6 +25,6 @@
 # Monitoring and management API documentation
 
 <div id="api" data-role="content">
-	<iframe src="../api/jdk8/jre/management/extension/index.html?view=embed" title="API viewer" name="apiframe" allow="autoplay *; fullscreen *; encrypted-media *" allowfullscreen="true" webkitallowfullscreen="true" mozallowfullscreen="true" style="min-height:80vh; width: 100%;">
+	<iframe src="{% if config.use_directory_urls %}../{% endif %}api/jdk8/jre/management/extension/index.html?view=embed" title="API viewer" name="apiframe" allow="autoplay *; fullscreen *; encrypted-media *" allowfullscreen="true" webkitallowfullscreen="true" mozallowfullscreen="true" style="min-height:80vh; width: 100%;">
 	</iframe>
 </div>

--- a/docs/api-shrc.md
+++ b/docs/api-shrc.md
@@ -25,6 +25,6 @@
 # Shared classes API documentation
 
 <div id="api" data-role="content">
-	<iframe src="../api/jdk8/platform/sharedclasses/index.html?view=embed" title="API viewer" name="apiframe" allow="autoplay *; fullscreen *; encrypted-media *" allowfullscreen="true" webkitallowfullscreen="true" mozallowfullscreen="true" style="min-height:80vh; width: 100%;">
+	<iframe src="{% if config.use_directory_urls %}../{% endif %}api/jdk8/platform/sharedclasses/index.html?view=embed" title="API viewer" name="apiframe" allow="autoplay *; fullscreen *; encrypted-media *" allowfullscreen="true" webkitallowfullscreen="true" mozallowfullscreen="true" style="min-height:80vh; width: 100%;">
 	</iframe>
 </div>

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -51,6 +51,10 @@ docs_dir: 'docs'
 
 site_dir: 'site'
 
+plugins:
+    - search
+    - macros
+
 extra_css:
   - 'stylesheets/oj9.css'
 


### PR DESCRIPTION
Includes updates to:
- Switch search off for the offline build . The material theme does not support search on local sites
- Correct the table layout in Supported environments which is broken by the material upgrade
- Use the `mkdocs-macros-plugin` to allow correct links  to offline api doc
- Fix relative urls to api docs due to path changes caused by use_directory_urls
- Explain how to reference non-Markdown files in the contributions guidelines