### PR TITLE
Add new default GC Scan Ordering for Balanced

### DIFF
--- a/docs/gc_overview.md
+++ b/docs/gc_overview.md
@@ -150,7 +150,7 @@ A GC *copy forward* operation is similar to a scavenge operation but is triggere
 
 2. Main
 
-    The list of reachable root objects in the work stack is recursively traced for references to other objects in the heap<!-- by using *dynamic breadth first scan ordering* mode ([`-Xgc:dynamicBreadthFirstScanOrdering`](xgc.md#dynamicbreadthfirstscanordering))-->. If new objects are found, they are added to the work stack. If an object is reachable, it is moved to another region of the same age or to an empty region of the same age in the heap. The age of all regions in the heap is then incremented by 1, except for the oldest region (age 24).
+    The list of reachable root objects in the work stack is recursively traced for references to other objects in the heap by using *dynamic breadth first scan ordering* mode ([`-Xgc:dynamicBreadthFirstScanOrdering`](xgc.md#dynamicbreadthfirstscanordering)). If new objects are found, they are added to the work stack. If an object is reachable, it is moved to another region of the same age or to an empty region of the same age in the heap. The age of all regions in the heap is then incremented by 1, except for the oldest region (age 24).
 
 3. Final
 

--- a/docs/version0.27.md
+++ b/docs/version0.27.md
@@ -28,6 +28,7 @@ The following new features and notable changes since v 0.26.0 are included in th
 
 - [New `-XX:[+|-]AdaptiveGCThreading` option added](#new-xx-adaptivegcthreading-option-added)
 - [Improved time zone information added to Java dump files](#improved-time-zone-information-added-to-java-dump-files)
+- [Change in default behavior for the `balanced` garbage collection policy](#change-in-default-behavior-for-the-balanced-garbage-collection-gc-policy)
 
 ## Features and changes
 
@@ -41,5 +42,13 @@ Use the [`-xgcmaxthreads`](xgcmaxthreads.md) option with the [`-XX:+AdaptiveGCTh
 ### Improved time zone information added to Java dump files
 
 To help with troubleshooting, additional time zone information is added to Java dump files. Two new fields are included, the date and time in UTC (`1TIDATETIMEUTC`) and the time zone according to the local system (`1TITIMEZONE`). For more information, see the [Java dump `TITLE` section](dump_javadump.md#title).
+
+### Change in default behavior for the `balanced` garbage collection (GC) policy
+
+In this release, a new scan mode, [`-Xgc:dynamicBreadthFirstScanOrdering`](xgc.md#dynamicbreadthfirstscanordering), is used during `balanced` GC copy forward operations that is expected to improve performance.
+
+For more information about this type of operation, see [GC copy forward operation](gc_overview.md#gc-copy-forward-operation).
+
+You can revert to the behavior in earlier releases by setting [`-Xgc:breadthFirstScanOrdering`](xgc.md#breadthfirstscanordering) when you start your application.
 
 <!-- ==== END OF TOPIC ==== version0.27.md ==== -->

--- a/docs/xgc.md
+++ b/docs/xgc.md
@@ -40,6 +40,7 @@ Options that change the behavior of the garbage collector.
 | [`concurrentScavenge`               ](#concurrentscavenge               ) | Enables a GC mode with less pause times.                                             |
 | [`dnssExpectedTimeRatioMaximum`     ](#dnssexpectedtimeratiomaximum     ) | Sets the maximum time to spend on GC of the nursery area.                                                 |
 | [`dnssExpectedTimeRatioMinimum`     ](#dnssexpectedtimeratiominimum     ) | Sets the minimum time to spend on GC of the nursery area.                                                 |
+| [`dynamicBreadthFirstScanOrdering`  ](#dynamicbreadthfirstscanordering  ) | Sets scan mode to dynamic breadth first.                                             |
 | [`excessiveGCratio`                 ](#excessivegcratio                 ) | Sets a boundary value beyond which GC is deemed to be excessive.                                          |
 | [`hierarchicalScanOrdering`         ](#hierarchicalscanordering         ) | Sets scan mode to hierarchical.                                             |
 | [`minContractPercent`               ](#mincontractpercent               ) | Sets the minimum percentage of the heap that can be contracted at any given time.                         |
@@ -64,7 +65,7 @@ Options that change the behavior of the garbage collector.
 
          -Xgc:breadthFirstScanOrdering
 
-: This option sets the scan mode for GC operations that evacuate objects in the heap (scavenge operations (`gencon`) and copy forward operations (`balanced`)) to breadth first mode. The scan mode reflects the method for traversing the object graph and is also known as *Cheney's algorithm*. This mode is the default for the `balanced` GC policy.
+: This option sets the scan mode for GC operations that evacuate objects in the heap (scavenge operations (`gencon`) and copy forward operations (`balanced`)) to breadth first mode. The scan mode reflects the method for traversing the object graph and is also known as *Cheney's algorithm*.
 
 ### `classUnloadingKickoffThreshold`
 
@@ -143,11 +144,11 @@ Options that change the behavior of the garbage collector.
 
 : This option applies only to the `gencon` GC policy.
 
-<!--### `dynamicBreadthFirstScanOrdering`
+### `dynamicBreadthFirstScanOrdering`
 
          -Xgc:dynamicBreadthFirstScanOrdering
 
-: This option sets the scan mode for GC operations that evacuate objects in the heap (scavenge operations (`gencon`) and copy forward operations (`balanced`)) to dynamic breadth first mode. This scan mode reflects the method for traversing the object graph and is a variant that adds *partial depth first traversal* on top of the breadth first scan mode. The aim of dynamic breadth first mode is driven by object field hotness. This mode is the default for the `balanced` GC policy.-->
+: This option sets the scan mode for GC operations that evacuate objects in the heap (scavenge operations (`gencon`) and copy forward operations (`balanced`)) to dynamic breadth first mode. This scan mode reflects the method for traversing the object graph and is a variant that adds *partial depth first traversal* on top of the breadth first scan mode. The aim of dynamic breadth first mode is driven by object field hotness. This mode is the default for the `balanced` GC policy.
 
 ### `excessiveGCratio`
 


### PR DESCRIPTION
Add the change in behavior for `balanced` to use a dynamic breadth-first scan ordering policy.

Closes: https://github.com/eclipse-openj9/openj9-docs/issues/703

Related to: https://github.com/eclipse-openj9/openj9/pull/12775

Signed-off-by: Jonathan Oommen <jon.oommen@gmail.com>
