### PR TITLE
Document -XX:+GlobalLockReservation as new default

### DIFF
--- a/docs/version0.27.md
+++ b/docs/version0.27.md
@@ -30,6 +30,7 @@ The following new features and notable changes since v 0.26.0 are included in th
 - [Improved time zone information added to Java dump files](#improved-time-zone-information-added-to-java-dump-files)
 - [Change in default behavior for the `balanced` garbage collection policy](#change-in-default-behavior-for-the-balanced-garbage-collection-gc-policy)
 - [Stop parsing the JAVA_OPTIONS environment variable](#stop-parsing-the-java_options-environment-variable)
+- [Global lock reservation enabled by default](#global-lock-reservation-enabled-by-default)
 
 ## Features and changes
 
@@ -60,5 +61,11 @@ You can revert to the behavior in earlier releases by setting [`-Xgc:breadthFirs
 
 The 0.24 release started parsing the JAVA_OPTIONS environment variable. This variable was added in error and has been removed.
 The [_JAVA_OPTIONS environment variable](cmdline_specifying.md) (with different behavior) is added for compatibility. 
+
+### Global lock reservation enabled by default
+
+**(AIX and Linux on Power systems only)**
+
+Global lock reservation is now enabled by default. This is an optimization targeted towards more efficient handling of locking and unlocking Java&trade; objects. The older locking behavior can be restored via the `-XX:-GlobalLockReservation` option. See [-XX:[+|-]GlobalLockReservation](xxgloballockreservation.md) for more details.
 
 <!-- ==== END OF TOPIC ==== version0.27.md ==== -->

--- a/docs/xxgloballockreservation.md
+++ b/docs/xxgloballockreservation.md
@@ -26,21 +26,23 @@
 
 **(AIX and Linux on Power systems only)**
 
-The `-XX:+GlobalLockReservation` option enables an optimization targeted towards more efficient handling of locking and unlocking Java&trade; objects.
+The `-XX:+GlobalLockReservation` option enables an optimization targeted towards more efficient handling of locking and unlocking Java&trade; objects. The `-XX:-GlobalLockReservation` option is used to disable this optimization. The optimization is enabled by default.
 
 ## Syntax
 
         -XX:[+|-]GlobalLockReservation
         -XX:+GlobalLockReservation:<parameter>
 
-| Setting                    | Effect | Default                                                                        |
-|----------------------------|--------|:------------------------------------------------------------------------------:|
-|`-XX:+GlobalLockReservation`| Enable |                                                                                |
-|`-XX:-GlobalLockReservation`| Disable| :fontawesome-solid-check:{: .yes aria-hidden="true"}<span class="sr-only">yes</span> |
+| Setting                    | Effect | Default                                                                              |
+|----------------------------|--------|:------------------------------------------------------------------------------------:|
+|`-XX:+GlobalLockReservation`| Enable | :fontawesome-solid-check:{: .yes aria-hidden="true"}<span class="sr-only">yes</span> |
+|`-XX:-GlobalLockReservation`| Disable|                                                                                      |
 
 This optimization is targeted towards applications with lots of uncontended locked objects that are being locked just to be safe. When enabled, heuristics are used to try and determine when an object will be exclusively locked by a single thread so that faster, more specialized code can be used for locking the object. If the heuristics incorrectly identify an object as a target for the optimization, performance might be adversely affected.
 
-The `-XX:-GlobalLockReservation` option turns off a previously enabled `-XX:+GlobalLockReservation` option.
+The `-XX:-GlobalLockReservation` option turns off global lock reservation.
+
+The `-XX:+GlobalLockReservation` option can be used to enable global lock reservation if it was disabled by an option that occurs earlier in command line processing or to modify some of the global lock reservation related suboptions that are described later in this document.
 
 ## Parameters
 


### PR DESCRIPTION
version0.27.md is updated to reflect that global lock reservation is now
enabled by default on AIX and Linux on Power.

Similarly, xxgloballockreservation.md is also updated to reflect this.

Closes: #799
Signed-off-by: jimmyk <jimmyk@ca.ibm.com>