### PR TITLE
Document -XX:Enable3164Interoperability

### DIFF
--- a/docs/xxenable3164interoperability.md
+++ b/docs/xxenable3164interoperability.md
@@ -1,5 +1,5 @@
 ﻿<!--
-* Copyright (c) 2017, 2021 IBM Corp. and others
+* Copyright (c) 2021, 2021 IBM Corp. and others
 *
 * This program and the accompanying materials are made
 * available under the terms of the Eclipse Public License 2.0

--- a/docs/xxenable3164interoperability.md
+++ b/docs/xxenable3164interoperability.md
@@ -1,0 +1,31 @@
+﻿<!--
+* Copyright (c) 2017, 2021 IBM Corp. and others
+*
+* This program and the accompanying materials are made
+* available under the terms of the Eclipse Public License 2.0
+* which accompanies this distribution and is available at
+* https://www.eclipse.org/legal/epl-2.0/ or the Apache
+* License, Version 2.0 which accompanies this distribution and
+* is available at https://www.apache.org/licenses/LICENSE-2.0.
+*
+* This Source Code may also be made available under the
+* following Secondary Licenses when the conditions for such
+* availability set forth in the Eclipse Public License, v. 2.0
+* are satisfied: GNU General Public License, version 2 with
+* the GNU Classpath Exception [1] and GNU General Public
+* License, version 2 with the OpenJDK Assembly Exception [2].
+*
+* [1] https://www.gnu.org/software/classpath/license.html
+* [2] http://openjdk.java.net/legal/assembly-exception.html
+*
+* SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH
+* Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+-->
+
+# -XX:[+|-]Enable3164Interoperability
+
+**(z/OS&reg; only)**
+
+Enables support for using 31-bit native applications with the 64-bit Java&trade; virtual machine, where that support is available. For more information, see [Using 31-bit native code with the 64-bit Java VM](https://www.ibm.com/docs/en/sdk-java-technology/8?topic=wja-using-31-bit-native-code-64-bit-java-vm-zos-only).
+
+<!-- ==== END OF TOPIC ==== xxenable3164interoperability.md ==== -->

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -348,6 +348,7 @@ nav:
             - "-XX:DiagnoseSyncOnValueBasedClasses"                              : xxdiagnosesynconvaluebasedclasses.md
             - "-XX:[+|-]DisableExplicitGC"                                       : xxdisableexplicitgc.md
             - "-XX:[+|-]DisclaimJitScratch"                                      : xxdisclaimjitscratch.md
+            - "-XX:[+|-]Enable3164Interoperability"                              : xxenable3164interoperability.md
             - "-XX:[+|-]EnableCPUMonitor"                                        : xxenablecpumonitor.md
             - "-XX:[+|-]ExitOnOutOfMemoryError"                                  : xxexitonoutofmemoryerror.md
             - "-XX:[+|-]GlobalLockReservation"                                   : xxgloballockreservation.md


### PR DESCRIPTION
This option enables 31/64-bit interop support for z/OS

Signed-off-by: Esther Dovey <doveye@uk.ibm.com>