### PR TITLE
Update URLs to reflect switch to github organization 'eclipse-openj9'

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -287,7 +287,7 @@ Jenkins doc stage
 Pull request builds are staged at the gh-pages branch of the https://github.com/eclipse-openj9/openj9-docs-staging repository. To view
 the staged draft of your documentation, visit the following URL, substituting &lt;PR&gt; with the number of your pull request:
 
-[`https://eclipse-openj9.github.io/openj9-docs-staging/<PR>`](https://eclipse.github.io/openj9-docs-staging/<PR>)
+[`https://eclipse-openj9.github.io/openj9-docs-staging/<PR>`](https://eclipse-openj9.github.io/openj9-docs-staging/<PR>)
 
 ## Accepting contributions
 

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ New to Eclipse OpenJ9? Here are a few links to get you started:
 - Read the [Getting started](https://www.eclipse.org/openj9/docs/introduction/) topic in our user documentation.
 
 The files in this repository are authored in markdown format and built using
-[Mkdocs](http://www.mkdocs.org/) with the [MkDocs-material theme](https://squidfunk.github.io/mkdocs-material/). Draft documentation for the next release is hosted via the gh-pages branch of this repository at the following URL: https://eclipse.github.io/openj9-docs/).
+[Mkdocs](http://www.mkdocs.org/) with the [MkDocs-material theme](https://squidfunk.github.io/mkdocs-material/). Draft documentation for the next release is hosted via the gh-pages branch of this repository at the following URL: https://eclipse-openj9.github.io/openj9-docs/).
 
 We welcome contributions to the user documentation. Please follow our
 [Contribution guidelines](CONTRIBUTING.md).

--- a/docs/index.md
+++ b/docs/index.md
@@ -50,7 +50,7 @@ OpenJDK binaries that contain the OpenJ9 VM are supported on a range of hardware
 Several versions of the documentation are available, covering all releases of OpenJ9:
 
 - [Online documentation for the last release](https://www.eclipse.org/openj9/docs/index.html)
-- [Online, in-progress documentation for the forthcoming release](https://eclipse.github.io/openj9-docs/)
+- [Online, in-progress documentation for the forthcoming release](https://eclipse-openj9.github.io/openj9-docs/)
 - [Downloads of earlier releases](https://github.com/eclipse-openj9/openj9-docs/tree/master/downloads): to download a zip file, click the filename, then click **Download**. After downloading a `.zip` file, extract it, then open the `index.html` file in your browser.
 
 ## Useful links


### PR DESCRIPTION
For example, https://openj9.github.io/openj9-docs-staging/ should be https://eclipse-openj9.github.io/openj9-docs-staging/.