### PR TITLE
Fix default -Xmint/-Xmaxt values

### DIFF
--- a/docs/xmint.md
+++ b/docs/xmint.md
@@ -39,8 +39,8 @@ Sets the minimum and maximum proportion of time to spend in the garbage collecti
 
 | Setting        | Effect                 | Default |
 |----------------|------------------------|---------|
-|`-Xmint<value>` | Set minimum time in GC | 5       |
-|`-Xmaxt<value>` | Set maximum time in GC | 13      |
+|`-Xmint<value>` | Set minimum time in GC | 0.05       |
+|`-Xmaxt<value>` | Set maximum time in GC | 0.13      |
 
 For the `gencon` GC policy, the values apply only to the tenure part of the heap. For the `balanced`, `optthruput`, and `optavgpause` GC policies, these values apply to the whole heap. This option cannot be used with the metronome GC policy (`-Xgcpolicy:metronome`) because the heap is always fully expanded.
 


### PR DESCRIPTION
The format of the values listed should be a percentage (see https://github.com/eclipse-openj9/openj9-docs/issues/803)

Signed-off-by: Esther Dovey <doveye@uk.ibm.com>