### PR TITLE
Add the initial draft "Release note" topic for 0.28

### DIFF
--- a/docs/version0.28.md
+++ b/docs/version0.28.md
@@ -1,0 +1,50 @@
+<!--
+* Copyright (c) 2021, 2021 IBM Corp. and others
+*
+* This program and the accompanying materials are made
+* available under the terms of the Eclipse Public License 2.0
+* which accompanies this distribution and is available at
+* https://www.eclipse.org/legal/epl-2.0/ or the Apache
+* License, Version 2.0 which accompanies this distribution and
+* is available at https://www.apache.org/licenses/LICENSE-2.0.
+*
+* This Source Code may also be made available under the
+* following Secondary Licenses when the conditions for such
+* availability set forth in the Eclipse Public License, v. 2.0
+* are satisfied: GNU General Public License, version 2 with
+* the GNU Classpath Exception [1] and GNU General Public
+* License, version 2 with the OpenJDK Assembly Exception [2].
+*
+* [1] https://www.gnu.org/software/classpath/license.html
+* [2] http://openjdk.java.net/legal/assembly-exception.html
+*
+* SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH
+* Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+-->
+
+# What's new in version 0.28.0
+
+The following new features and notable changes since v 0.27.0 are included in this release:
+
+- [New binaries and changes to supported environments](#binaries-and-supported-environments)
+- [Next item](#next-item)
+
+
+## Features and changes
+
+### Binaries and supported environments
+
+OpenJ9 release 0.28.0 supports OpenJDK 17. OpenJDK 17 with Eclipse OpenJ9 is a long term support (LTS) release and supersedes OpenJDK 11 with Eclipse OpenJ9.
+
+Although it might be possible to build an OpenJDK 8 or OpenJDK 11 with OpenJ9 release 0.28.0, testing at the project is not complete and therefore support for new features that apply to these Java versions is not available.
+
+To learn more about support for OpenJ9 releases, including OpenJDK levels and platform support, see [Supported environments](openj9_support.md).
+
+### Next item ###
+<!-- Replace this with the next new feature for 0.28 and update the URL list near the top of the topic to point to this section -->
+
+## Full release information
+
+To see a complete list of changes between Eclipse OpenJ9 v0.27.0 and v0.28.0 releases, see the [Release notes](https://github.com/eclipse-openj9/openj9/blob/master/doc/release-notes/0.28/0.28.md).
+
+<!-- ==== END OF TOPIC ==== version0.27.md ==== -->

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -102,11 +102,12 @@ nav:
 
     - "Release notes" :
         - "Overview"                                                             : openj9_releases.md
+        - "Version 0.28.0"                                                       : version0.28.md
         - "Version 0.27.0"                                                       : version0.27.md
         - "Version 0.26.0"                                                       : version0.26.md
         - "Version 0.25.0"                                                       : version0.25.md
-        - "Version 0.24.0"                                                       : version0.24.md
         - "Earlier releases" :
+            - "Version 0.24.0"                                                   : version0.24.md
             - "Version 0.23.0"                                                   : version0.23.md
             - "Version 0.22.0"                                                   : version0.22.md
             - "Version 0.21.0"                                                   : version0.21.md


### PR DESCRIPTION
Add the initial draft "Release note" topic for 0.28, ready for updates for each feature as it comes.

This release is to support JDK 17 (next LTS), so add content to mention that.

Also move one of the previous "Release note" topics into the "Earlier releases" section to avoid cluttering the table of contents.

Signed-off-by: Esther Dovey doveye@uk.ibm.com