### PR TITLE
Change documentation on z/OS default cache directory

### DIFF
--- a/docs/shrc.md
+++ b/docs/shrc.md
@@ -61,7 +61,7 @@ These cache utilities are discussed in more detail in the sections that follow.
 Class data sharing is enabled by default for bootstrap classes, unless your application is running in a container.
 Default behavior includes the following characteristics:
 
-- The cache is created in the `javasharedresources` directory in the users home directory, unless the `groupAccess` parameter is specified, in which case it is created in `/tmp/javasharedresources`. However, on Windows&reg;, it is created in the user's `C:\Documents and Settings\<username>\Local Settings\Application Data\javasharedresources` directory.
+- On Windows&reg;, the cache is created in the user's `C:\Documents and Settings\<username>\Local Settings\Application Data\javasharedresources` directory. On z/OS&reg;, the default cache directory is `/tmp/javasharedresources`. On other systems, the cache is created in the `javasharedresources` directory in the users home directory, unless the `groupAccess` parameter is specified, in which case it is created in `/tmp/javasharedresources`. Please do not set the home directory on a NFS mount or shared mount across systems or LPARs. 
 - The cache name is `sharedcc_%u`, where `%u` is the current user name.
 - If class data sharing fails, the VM still starts without printing any errors.
 
@@ -141,7 +141,7 @@ The [-Xshareclasses](xshareclasses.md) option is highly configurable, allowing y
 
 - Set a specific cache directory ([`-Xshareclasses:cacheDir=<directory>`](xshareclasses.md#cachedir)).
 
-    Set a cache directory that is specific to your application, to  avoid sharing the default cache directory with the default cache, or other application caches that don't set a cache directory. Your application will be unaffected by a user running [`java -Xshareclasses:destroyAll`](xshareclasses.md#destroyall-cache-utility).
+    Set a cache directory that is specific to your application, to  avoid sharing the default cache directory with the default cache, or other application caches that don't set a cache directory. Your application will be unaffected by a user running [`java -Xshareclasses:destroyAll`](xshareclasses.md#destroyall-cache-utility). Please do not set the cache directory on a NFS mount or a shared mount across systems or LPARs.
 
     In addition, if you have VMs from different Java installations, of the same Java release and installed by the same user, each VM checks whether the existing default shared cache in the cache directory is from the same Java installation as the VM. If not, the VM deletes that shared cache, then creates a new one. Specifying a different cache directory for each Java installation avoids this situation.
 

--- a/docs/shrc_diag_util.md
+++ b/docs/shrc_diag_util.md
@@ -31,7 +31,8 @@ If you encounter problems with class data sharing, VM messages are typically gen
 If you do not specify a directory for the shared classes cache by using the `cacheDir` suboption, the cache is created in the `javasharedresources` directory in the following default location:
 
 - On Windows&reg; systems, this directory is created in the user's `C:\Documents and Settings\<username>\Local Settings\Application Data\` directory.
-- On other systems, this directory is located in the user's home directory.
+- On z/OS&reg; systems, this directory is created in the `/tmp` directory.
+- On other systems, this directory is located in the user's home directory. Please do not set user's home on a NFS mount or a shared mount across systems or LPARs.
 
 Initialization problems can occur on systems other than Windows because caches are created with read/write access for the user only and subsequent users do not have permission to write to the home directory. If you specify the `-Xshareclasses:groupAccess` suboption, the cache is created in the `/tmp` directory instead where all users have permission to write to the cache.
 

--- a/docs/xshareclasses.md
+++ b/docs/xshareclasses.md
@@ -91,12 +91,13 @@ When you specify `-Xshareclasses` without any parameters and without specifying 
 
         -Xshareclasses:cacheDir=<directory>
 
-: Sets the directory in which cache data is read and written. The following defaults apply:
+: Sets the directory in which cache data is read and written. Please do not set the cache directory on a NFS mount or a shared mount across systems or LPARs. The following defaults apply:
 
     - On Windows&trade; systems, `<directory>` is the user's `C:\Documents and Settings\<username>\Local Settings\Application Data\javasharedresources` directory.
-    - On other operating systems, `<directory>` is `javasharedresources` in the user's home directory, unless the `groupAccess` parameter is specified, in which case it is `/tmp/javasharedresources`, because some members of the group might not have access to the user's home directory. You must have sufficient permissions in `<directory>`.
+    - On z/OS&reg; systems, `<directory>` is the `/tmp/javasharedresources` directory.
+    - On other operating systems, `<directory>` is `javasharedresources` in the user's home directory, unless the `groupAccess` parameter is specified, in which case it is `/tmp/javasharedresources`, because some members of the group might not have access to the user's home directory. You must have sufficient permissions in `<directory>`. Do not set user's home directory on a NFS or shared mount.
 
-: On AIX&reg;, Linux, macOS, and Windows systems, the VM writes persistent cache files directly into the directory specified. Persistent cache files can be safely moved and deleted from the file system. For persistent caches, the directory must not be on an NFS mount.
+: On AIX&reg;, Linux, macOS, and Windows systems, the VM writes persistent cache files directly into the directory specified. Persistent cache files can be safely moved and deleted from the file system.
 
 : Non-persistent caches are stored in shared memory and have control files that describe the location of the memory. Control files are stored in a `javasharedresources` subdirectory of the `cacheDir` specified. Do not move or delete control files in this directory. The `listAllCaches` utility, the `destroyAll` utility, and the `expire` suboption work only in the scope of a given `cacheDir`.
 


### PR DESCRIPTION
1. The z/OS default cache directory is /tmp/javasharedresources
2. Add message that the cache directory should not be set on NFS or
shared mount.

Closes #828

Signed-off-by: Hang Shao <hangshao@ca.ibm.com>