### PR TITLE
Move the build job to alinux

### DIFF
--- a/JenkinsFile_build_doc.groovy
+++ b/JenkinsFile_build_doc.groovy
@@ -76,7 +76,7 @@ switch (params.BUILD_TYPE) {
 
 timeout(time: 6, unit: 'HOURS') {
     timestamps {
-        node('hw.arch.x86&&sw.tool.docker') {
+        node('hw.arch.aarch64&&sw.tool.docker') {
             try {
                 def TMP_DESC = (currentBuild.description) ? currentBuild.description + "<br>" : ""
                 currentBuild.description = TMP_DESC + "<a href=${JENKINS_URL}computer/${NODE_NAME}>${NODE_NAME}</a>"


### PR DESCRIPTION
xlinux is slow in good times, and having networking issues atm. If it
works, should be much faster on alinux.

Signed-off-by: Peter Shipton <Peter_Shipton@ca.ibm.com>