### PR TITLE
(0.29.1) Add 0.29.1 release notes

### DIFF
--- a/docs/version0.29.1.md
+++ b/docs/version0.29.1.md
@@ -1,0 +1,45 @@
+<!--
+* Copyright (c) 2021, 2021 IBM Corp. and others
+*
+* This program and the accompanying materials are made
+* available under the terms of the Eclipse Public License 2.0
+* which accompanies this distribution and is available at
+* https://www.eclipse.org/legal/epl-2.0/ or the Apache
+* License, Version 2.0 which accompanies this distribution and
+* is available at https://www.apache.org/licenses/LICENSE-2.0.
+*
+* This Source Code may also be made available under the
+* following Secondary Licenses when the conditions for such
+* availability set forth in the Eclipse Public License, v. 2.0
+* are satisfied: GNU General Public License, version 2 with
+* the GNU Classpath Exception [1] and GNU General Public
+* License, version 2 with the OpenJDK Assembly Exception [2].
+*
+* [1] https://www.gnu.org/software/classpath/license.html
+* [2] http://openjdk.java.net/legal/assembly-exception.html
+*
+* SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH
+* Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+-->
+
+# What's new in version 0.29.1
+
+The following new features and notable changes since v 0.29.0 are included in this release:
+
+- [New binaries and changes to supported environments](#binaries-and-supported-environments)
+
+## Features and changes
+
+### Binaries and supported environments
+
+OpenJ9 release 0.29.1 supports OpenJDK 17.
+
+AArch64 Linux is now a fully supported, production-ready target for OpenJDK 17.
+
+To learn more about support for OpenJ9 releases, including OpenJDK levels and platform support, see [Supported environments](openj9_support.md).
+
+## Full release information
+
+To see a complete list of changes between Eclipse OpenJ9 v0.29.0 and v0.29.1 releases, see the [Release notes](https://github.com/eclipse-openj9/openj9/blob/master/doc/release-notes/0.29/0.29.1.md).
+
+<!-- ==== END OF TOPIC ==== version0.29.1.md ==== -->

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -102,11 +102,12 @@ nav:
 
     - "Release notes" :
         - "Overview"                                                             : openj9_releases.md
+        - "Version 0.29.1"                                                       : version0.29.1.md
         - "Version 0.29.0"                                                       : version0.29.md
         - "Version 0.27.0"                                                       : version0.27.md
         - "Version 0.26.0"                                                       : version0.26.md
-        - "Version 0.25.0"                                                       : version0.25.md
         - "Earlier releases" :
+            - "Version 0.25.0"                                                   : version0.25.md
             - "Version 0.24.0"                                                   : version0.24.md
             - "Version 0.23.0"                                                   : version0.23.md
             - "Version 0.22.0"                                                   : version0.22.md


### PR DESCRIPTION
Port of https://github.com/eclipse-openj9/openj9-docs/pull/868 for the 0.29.1 release branch.

Signed-off-by: Peter Shipton <Peter_Shipton@ca.ibm.com>