### PR TITLE
(0.30.0) Update copyright year to 2022

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,5 +1,5 @@
 <!--
-* Copyright (c) 2017, 2021 IBM Corp. and others
+* Copyright (c) 2017, 2022 IBM Corp. and others
 *
 * This program and the accompanying materials are made
 * available under the terms of the Eclipse Public License 2.0

--- a/JenkinsFile_build_container.groovy
+++ b/JenkinsFile_build_container.groovy
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2021 IBM Corp. and others
+ * Copyright (c) 2017, 2022 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this

--- a/JenkinsFile_build_doc.groovy
+++ b/JenkinsFile_build_doc.groovy
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2021 IBM Corp. and others
+ * Copyright (c) 2017, 2022 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this

--- a/NOTICE.md
+++ b/NOTICE.md
@@ -1,5 +1,5 @@
 <!--
-* Copyright (c) 2017, 2021 IBM Corp. and others
+* Copyright (c) 2017, 2022 IBM Corp. and others
 *
 * This program and the accompanying materials are made
 * available under the terms of the Eclipse Public License 2.0

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <!--
-* Copyright (c) 2017, 2021 IBM Corp. and others
+* Copyright (c) 2017, 2022 IBM Corp. and others
 *
 * This program and the accompanying materials are made
 * available under the terms of the Eclipse Public License 2.0

--- a/buildenv/Dockerfile
+++ b/buildenv/Dockerfile
@@ -1,16 +1,24 @@
-# (C) Copyright IBM Corporation 2016, 2021
+# Copyright (c) 2017, 2022 IBM Corp. and others
 #
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
+# This program and the accompanying materials are made
+# available under the terms of the Eclipse Public License 2.0
+# which accompanies this distribution and is available at
+# https://www.eclipse.org/legal/epl-2.0/ or the Apache
+# License, Version 2.0 which accompanies this distribution and
+# is available at https://www.apache.org/licenses/LICENSE-2.0.
 #
-#      http://www.apache.org/licenses/LICENSE-2.0
+# This Source Code may also be made available under the
+# following Secondary Licenses when the conditions for such
+# availability set forth in the Eclipse Public License, v. 2.0
+# are satisfied: GNU General Public License, version 2 with
+# the GNU Classpath Exception [1] and GNU General Public
+# License, version 2 with the OpenJDK Assembly Exception [2].
 #
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# [1] https://www.gnu.org/software/classpath/license.html
+# [2] http://openjdk.java.net/legal/assembly-exception.html
+#
+# SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH
+# Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
 #
 
 FROM ubuntu:18.04

--- a/buildenv/requirements.in
+++ b/buildenv/requirements.in
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2017, 2021 IBM Corp. and others
+# Copyright (c) 2017, 2022 IBM Corp. and others
 #
 # This program and the accompanying materials are made
 # available under the terms of the Eclipse Public License 2.0

--- a/buildenv/requirements.txt
+++ b/buildenv/requirements.txt
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2017, 2021 IBM Corp. and others
+# Copyright (c) 2017, 2022 IBM Corp. and others
 #
 # This program and the accompanying materials are made
 # available under the terms of the Eclipse Public License 2.0

--- a/docs/allocation.md
+++ b/docs/allocation.md
@@ -1,5 +1,5 @@
 <!--
-* Copyright (c) 2017, 2021 IBM Corp. and others
+* Copyright (c) 2017, 2022 IBM Corp. and others
 *
 * This program and the accompanying materials are made
 * available under the terms of the Eclipse Public License 2.0

--- a/docs/aot.md
+++ b/docs/aot.md
@@ -1,5 +1,5 @@
 <!--
-* Copyright (c) 2017, 2021 IBM Corp. and others
+* Copyright (c) 2017, 2022 IBM Corp. and others
 *
 * This program and the accompanying materials are made
 * available under the terms of the Eclipse Public License 2.0

--- a/docs/api-conditionhandling.md
+++ b/docs/api-conditionhandling.md
@@ -1,5 +1,5 @@
 <!--
-* Copyright (c) 2017, 2021 IBM Corp. and others
+* Copyright (c) 2017, 2022 IBM Corp. and others
 *
 * This program and the accompanying materials are made
 * available under the terms of the Eclipse Public License 2.0

--- a/docs/api-cuda.md
+++ b/docs/api-cuda.md
@@ -1,5 +1,5 @@
 <!--
-* Copyright (c) 2017, 2021 IBM Corp. and others
+* Copyright (c) 2017, 2022 IBM Corp. and others
 *
 * This program and the accompanying materials are made
 * available under the terms of the Eclipse Public License 2.0

--- a/docs/api-daa.md
+++ b/docs/api-daa.md
@@ -1,5 +1,5 @@
 <!--
-* Copyright (c) 2017, 2021 IBM Corp. and others
+* Copyright (c) 2017, 2022 IBM Corp. and others
 *
 * This program and the accompanying materials are made
 * available under the terms of the Eclipse Public License 2.0

--- a/docs/api-dtfj.md
+++ b/docs/api-dtfj.md
@@ -1,5 +1,5 @@
 <!--
-* Copyright (c) 2017, 2021 IBM Corp. and others
+* Copyright (c) 2017, 2022 IBM Corp. and others
 *
 * This program and the accompanying materials are made
 * available under the terms of the Eclipse Public License 2.0

--- a/docs/api-gpu.md
+++ b/docs/api-gpu.md
@@ -1,5 +1,5 @@
 <!--
-* Copyright (c) 2017, 2021 IBM Corp. and others
+* Copyright (c) 2017, 2022 IBM Corp. and others
 *
 * This program and the accompanying materials are made
 * available under the terms of the Eclipse Public License 2.0

--- a/docs/api-jdk11.md
+++ b/docs/api-jdk11.md
@@ -1,5 +1,5 @@
 <!--
-* Copyright (c) 2017, 2021 IBM Corp. and others
+* Copyright (c) 2017, 2022 IBM Corp. and others
 *
 * This program and the accompanying materials are made
 * available under the terms of the Eclipse Public License 2.0

--- a/docs/api-jdk17.md
+++ b/docs/api-jdk17.md
@@ -1,5 +1,5 @@
 <!--
-* Copyright (c) 2017, 2021 IBM Corp. and others
+* Copyright (c) 2017, 2022 IBM Corp. and others
 *
 * This program and the accompanying materials are made
 * available under the terms of the Eclipse Public License 2.0

--- a/docs/api-jvm.md
+++ b/docs/api-jvm.md
@@ -1,5 +1,5 @@
 <!--
-* Copyright (c) 2017, 2021 IBM Corp. and others
+* Copyright (c) 2017, 2022 IBM Corp. and others
 *
 * This program and the accompanying materials are made
 * available under the terms of the Eclipse Public License 2.0

--- a/docs/api-langmgmt.md
+++ b/docs/api-langmgmt.md
@@ -1,5 +1,5 @@
 <!--
-* Copyright (c) 2017, 2021 IBM Corp. and others
+* Copyright (c) 2017, 2022 IBM Corp. and others
 *
 * This program and the accompanying materials are made
 * available under the terms of the Eclipse Public License 2.0

--- a/docs/api-overview.md
+++ b/docs/api-overview.md
@@ -1,5 +1,5 @@
 <!--
-* Copyright (c) 2017, 2021 IBM Corp. and others
+* Copyright (c) 2017, 2022 IBM Corp. and others
 *
 * This program and the accompanying materials are made
 * available under the terms of the Eclipse Public License 2.0

--- a/docs/api-shrc.md
+++ b/docs/api-shrc.md
@@ -1,5 +1,5 @@
 <!--
-* Copyright (c) 2017, 2021 IBM Corp. and others
+* Copyright (c) 2017, 2022 IBM Corp. and others
 *
 * This program and the accompanying materials are made
 * available under the terms of the Eclipse Public License 2.0

--- a/docs/attachapi.md
+++ b/docs/attachapi.md
@@ -1,3 +1,27 @@
+<!--
+* Copyright (c) 2017, 2022 IBM Corp. and others
+*
+* This program and the accompanying materials are made
+* available under the terms of the Eclipse Public License 2.0
+* which accompanies this distribution and is available at
+* https://www.eclipse.org/legal/epl-2.0/ or the Apache
+* License, Version 2.0 which accompanies this distribution and
+* is available at https://www.apache.org/licenses/LICENSE-2.0.
+*
+* This Source Code may also be made available under the
+* following Secondary Licenses when the conditions for such
+* availability set forth in the Eclipse Public License, v. 2.0
+* are satisfied: GNU General Public License, version 2 with
+* the GNU Classpath Exception [1] and GNU General Public
+* License, version 2 with the OpenJDK Assembly Exception [2].
+*
+* [1] https://www.gnu.org/software/classpath/license.html
+* [2] http://openjdk.java.net/legal/assembly-exception.html
+*
+* SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH
+* Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+-->
+
 # Java Attach API
 
 With the Attach API, your application can connect to a running VM and load an agent into that VM to run tasks. The typical use case for this feature is to load an agent that can be used to monitor the application that's running in the target VM.

--- a/docs/builds.md
+++ b/docs/builds.md
@@ -1,4 +1,26 @@
-
+<!--
+* Copyright (c) 2017, 2022 IBM Corp. and others
+*
+* This program and the accompanying materials are made
+* available under the terms of the Eclipse Public License 2.0
+* which accompanies this distribution and is available at
+* https://www.eclipse.org/legal/epl-2.0/ or the Apache
+* License, Version 2.0 which accompanies this distribution and
+* is available at https://www.apache.org/licenses/LICENSE-2.0.
+*
+* This Source Code may also be made available under the
+* following Secondary Licenses when the conditions for such
+* availability set forth in the Eclipse Public License, v. 2.0
+* are satisfied: GNU General Public License, version 2 with
+* the GNU Classpath Exception [1] and GNU General Public
+* License, version 2 with the OpenJDK Assembly Exception [2].
+*
+* [1] https://www.gnu.org/software/classpath/license.html
+* [2] http://openjdk.java.net/legal/assembly-exception.html
+*
+* SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH
+* Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+-->
 
 # OpenJ9 builds
 

--- a/docs/cmdline_general.md
+++ b/docs/cmdline_general.md
@@ -1,5 +1,5 @@
 <!--
-* Copyright (c) 2017, 2021 IBM Corp. and others
+* Copyright (c) 2017, 2022 IBM Corp. and others
 *
 * This program and the accompanying materials are made
 * available under the terms of the Eclipse Public License 2.0

--- a/docs/cmdline_migration.md
+++ b/docs/cmdline_migration.md
@@ -1,5 +1,5 @@
 ﻿<!--
-* Copyright (c) 2017, 2021 IBM Corp. and others
+* Copyright (c) 2017, 2022 IBM Corp. and others
 *
 * This program and the accompanying materials are made
 * available under the terms of the Eclipse Public License 2.0

--- a/docs/cmdline_specifying.md
+++ b/docs/cmdline_specifying.md
@@ -1,5 +1,5 @@
 <!--
-* Copyright (c) 2017, 2021 IBM Corp. and others
+* Copyright (c) 2017, 2022 IBM Corp. and others
 *
 * This program and the accompanying materials are made
 * available under the terms of the Eclipse Public License 2.0

--- a/docs/configuring.md
+++ b/docs/configuring.md
@@ -1,5 +1,5 @@
 <!--
-* Copyright (c) 2017, 2021 IBM Corp. and others
+* Copyright (c) 2017, 2022 IBM Corp. and others
 *
 * This program and the accompanying materials are made
 * available under the terms of the Eclipse Public License 2.0

--- a/docs/d_jvm_commands.md
+++ b/docs/d_jvm_commands.md
@@ -1,5 +1,5 @@
 <!--
-* Copyright (c) 2017, 2021 IBM Corp. and others
+* Copyright (c) 2017, 2022 IBM Corp. and others
 *
 * This program and the accompanying materials are made
 * available under the terms of the Eclipse Public License 2.0

--- a/docs/dcomibmenableclasscaching.md
+++ b/docs/dcomibmenableclasscaching.md
@@ -1,5 +1,5 @@
 <!--
-* Copyright (c) 2017, 2021 IBM Corp. and others
+* Copyright (c) 2017, 2022 IBM Corp. and others
 *
 * This program and the accompanying materials are made
 * available under the terms of the Eclipse Public License 2.0

--- a/docs/dcomibmenablelegacydumpsecurity.md
+++ b/docs/dcomibmenablelegacydumpsecurity.md
@@ -1,5 +1,5 @@
 <!--
-* Copyright (c) 2017, 2021 IBM Corp. and others
+* Copyright (c) 2017, 2022 IBM Corp. and others
 *
 * This program and the accompanying materials are made
 * available under the terms of the Eclipse Public License 2.0

--- a/docs/dcomibmenablelegacylogsecurity.md
+++ b/docs/dcomibmenablelegacylogsecurity.md
@@ -1,5 +1,5 @@
 <!--
-* Copyright (c) 2017, 2021 IBM Corp. and others
+* Copyright (c) 2017, 2022 IBM Corp. and others
 *
 * This program and the accompanying materials are made
 * available under the terms of the Eclipse Public License 2.0

--- a/docs/dcomibmenablelegacytracesecurity.md
+++ b/docs/dcomibmenablelegacytracesecurity.md
@@ -1,5 +1,5 @@
 <!--
-* Copyright (c) 2017, 2021 IBM Corp. and others
+* Copyright (c) 2017, 2022 IBM Corp. and others
 *
 * This program and the accompanying materials are made
 * available under the terms of the Eclipse Public License 2.0

--- a/docs/dcomibmgpudisable.md
+++ b/docs/dcomibmgpudisable.md
@@ -1,5 +1,5 @@
 <!--
-* Copyright (c) 2017, 2021 IBM Corp. and others
+* Copyright (c) 2017, 2022 IBM Corp. and others
 *
 * This program and the accompanying materials are made
 * available under the terms of the Eclipse Public License 2.0

--- a/docs/dcomibmgpuenable.md
+++ b/docs/dcomibmgpuenable.md
@@ -1,5 +1,5 @@
 <!--
-* Copyright (c) 2017, 2021 IBM Corp. and others
+* Copyright (c) 2017, 2022 IBM Corp. and others
 *
 * This program and the accompanying materials are made
 * available under the terms of the Eclipse Public License 2.0

--- a/docs/dcomibmgpuverbose.md
+++ b/docs/dcomibmgpuverbose.md
@@ -1,5 +1,5 @@
 <!--
-* Copyright (c) 2017, 2021 IBM Corp. and others
+* Copyright (c) 2017, 2022 IBM Corp. and others
 *
 * This program and the accompanying materials are made
 * available under the terms of the Eclipse Public License 2.0

--- a/docs/dcomibmlangmanagementosmxbeaniscputime100ns.md
+++ b/docs/dcomibmlangmanagementosmxbeaniscputime100ns.md
@@ -1,5 +1,5 @@
 <!--
-* Copyright (c) 2017, 2021 IBM Corp. and others
+* Copyright (c) 2017, 2022 IBM Corp. and others
 *
 * This program and the accompanying materials are made
 * available under the terms of the Eclipse Public License 2.0

--- a/docs/dcomibmlangmanagementverbose.md
+++ b/docs/dcomibmlangmanagementverbose.md
@@ -1,5 +1,5 @@
 <!--
-* Copyright (c) 2017, 2021 IBM Corp. and others
+* Copyright (c) 2017, 2022 IBM Corp. and others
 *
 * This program and the accompanying materials are made
 * available under the terms of the Eclipse Public License 2.0

--- a/docs/dcomibmotisharedsharedclassglobalfilterclass.md
+++ b/docs/dcomibmotisharedsharedclassglobalfilterclass.md
@@ -1,5 +1,5 @@
 <!--
-* Copyright (c) 2017, 2021 IBM Corp. and others
+* Copyright (c) 2017, 2022 IBM Corp. and others
 *
 * This program and the accompanying materials are made
 * available under the terms of the Eclipse Public License 2.0

--- a/docs/dcomibmtoolsattachcommand_timeout.md
+++ b/docs/dcomibmtoolsattachcommand_timeout.md
@@ -1,5 +1,5 @@
 <!--
-* Copyright (c) 2017, 2021 IBM Corp. and others
+* Copyright (c) 2017, 2022 IBM Corp. and others
 *
 * This program and the accompanying materials are made
 * available under the terms of the Eclipse Public License 2.0

--- a/docs/dcomibmtoolsattachdirectory.md
+++ b/docs/dcomibmtoolsattachdirectory.md
@@ -1,5 +1,5 @@
 <!--
-* Copyright (c) 2017, 2021 IBM Corp. and others
+* Copyright (c) 2017, 2022 IBM Corp. and others
 *
 * This program and the accompanying materials are made
 * available under the terms of the Eclipse Public License 2.0

--- a/docs/dcomibmtoolsattachdisplayname.md
+++ b/docs/dcomibmtoolsattachdisplayname.md
@@ -1,5 +1,5 @@
 <!--
-* Copyright (c) 2017, 2021 IBM Corp. and others
+* Copyright (c) 2017, 2022 IBM Corp. and others
 *
 * This program and the accompanying materials are made
 * available under the terms of the Eclipse Public License 2.0

--- a/docs/dcomibmtoolsattachenable.md
+++ b/docs/dcomibmtoolsattachenable.md
@@ -1,5 +1,5 @@
 <!--
-* Copyright (c) 2017, 2021 IBM Corp. and others
+* Copyright (c) 2017, 2022 IBM Corp. and others
 *
 * This program and the accompanying materials are made
 * available under the terms of the Eclipse Public License 2.0

--- a/docs/dcomibmtoolsattachid.md
+++ b/docs/dcomibmtoolsattachid.md
@@ -1,5 +1,5 @@
 <!--
-* Copyright (c) 2017, 2021 IBM Corp. and others
+* Copyright (c) 2017, 2022 IBM Corp. and others
 *
 * This program and the accompanying materials are made
 * available under the terms of the Eclipse Public License 2.0

--- a/docs/dcomibmtoolsattachlogging.md
+++ b/docs/dcomibmtoolsattachlogging.md
@@ -1,5 +1,5 @@
 <!--
-* Copyright (c) 2017, 2021 IBM Corp. and others
+* Copyright (c) 2017, 2022 IBM Corp. and others
 *
 * This program and the accompanying materials are made
 * available under the terms of the Eclipse Public License 2.0

--- a/docs/dcomibmtoolsattachlogname.md
+++ b/docs/dcomibmtoolsattachlogname.md
@@ -1,5 +1,5 @@
 <!--
-* Copyright (c) 2017, 2021 IBM Corp. and others
+* Copyright (c) 2017, 2022 IBM Corp. and others
 *
 * This program and the accompanying materials are made
 * available under the terms of the Eclipse Public License 2.0

--- a/docs/dcomibmtoolsattachshutdown_timeout.md
+++ b/docs/dcomibmtoolsattachshutdown_timeout.md
@@ -1,5 +1,5 @@
 <!--
-* Copyright (c) 2017, 2021 IBM Corp. and others
+* Copyright (c) 2017, 2022 IBM Corp. and others
 *
 * This program and the accompanying materials are made
 * available under the terms of the Eclipse Public License 2.0

--- a/docs/dcomibmtoolsattachtimeout.md
+++ b/docs/dcomibmtoolsattachtimeout.md
@@ -1,5 +1,5 @@
 <!--
-* Copyright (c) 2017, 2021 IBM Corp. and others
+* Copyright (c) 2017, 2022 IBM Corp. and others
 *
 * This program and the accompanying materials are made
 * available under the terms of the Eclipse Public License 2.0

--- a/docs/dfileencoding.md
+++ b/docs/dfileencoding.md
@@ -1,5 +1,5 @@
 <!--
-* Copyright (c) 2017, 2021 IBM Corp. and others
+* Copyright (c) 2017, 2022 IBM Corp. and others
 *
 * This program and the accompanying materials are made
 * available under the terms of the Eclipse Public License 2.0

--- a/docs/diag_overview.md
+++ b/docs/diag_overview.md
@@ -1,5 +1,5 @@
 <!--
-* Copyright (c) 2017, 2021 IBM Corp. and others
+* Copyright (c) 2017, 2022 IBM Corp. and others
 *
 * This program and the accompanying materials are made
 * available under the terms of the Eclipse Public License 2.0

--- a/docs/djavacompiler.md
+++ b/docs/djavacompiler.md
@@ -1,5 +1,5 @@
 <!--
-* Copyright (c) 2017, 2021 IBM Corp. and others
+* Copyright (c) 2017, 2022 IBM Corp. and others
 *
 * This program and the accompanying materials are made
 * available under the terms of the Eclipse Public License 2.0

--- a/docs/djavalangstringbuffergrowaggressively.md
+++ b/docs/djavalangstringbuffergrowaggressively.md
@@ -1,5 +1,5 @@
 <!--
-* Copyright (c) 2017, 2021 IBM Corp. and others
+* Copyright (c) 2017, 2022 IBM Corp. and others
 *
 * This program and the accompanying materials are made
 * available under the terms of the Eclipse Public License 2.0

--- a/docs/djavalangstringsubstringnocopy.md
+++ b/docs/djavalangstringsubstringnocopy.md
@@ -1,5 +1,5 @@
 <!--
-* Copyright (c) 2017, 2021 IBM Corp. and others
+* Copyright (c) 2017, 2022 IBM Corp. and others
 *
 * This program and the accompanying materials are made
 * available under the terms of the Eclipse Public License 2.0

--- a/docs/djdknativecbc.md
+++ b/docs/djdknativecbc.md
@@ -1,5 +1,5 @@
 <!--
-* Copyright (c) 2017, 2021 IBM Corp. and others
+* Copyright (c) 2017, 2022 IBM Corp. and others
 *
 * This program and the accompanying materials are made
 * available under the terms of the Eclipse Public License 2.0

--- a/docs/djdknativechacha20.md
+++ b/docs/djdknativechacha20.md
@@ -1,5 +1,5 @@
 <!--
-* Copyright (c) 2017, 2021 IBM Corp. and others
+* Copyright (c) 2017, 2022 IBM Corp. and others
 *
 * This program and the accompanying materials are made
 * available under the terms of the Eclipse Public License 2.0

--- a/docs/djdknativecrypto.md
+++ b/docs/djdknativecrypto.md
@@ -1,5 +1,5 @@
 <!--
-* Copyright (c) 2017, 2021 IBM Corp. and others
+* Copyright (c) 2017, 2022 IBM Corp. and others
 *
 * This program and the accompanying materials are made
 * available under the terms of the Eclipse Public License 2.0

--- a/docs/djdknativedigest.md
+++ b/docs/djdknativedigest.md
@@ -1,5 +1,5 @@
 <!--
-* Copyright (c) 2017, 2021 IBM Corp. and others
+* Copyright (c) 2017, 2022 IBM Corp. and others
 *
 * This program and the accompanying materials are made
 * available under the terms of the Eclipse Public License 2.0

--- a/docs/djdknativegcm.md
+++ b/docs/djdknativegcm.md
@@ -1,5 +1,5 @@
 <!--
-* Copyright (c) 2017, 2021 IBM Corp. and others
+* Copyright (c) 2017, 2022 IBM Corp. and others
 *
 * This program and the accompanying materials are made
 * available under the terms of the Eclipse Public License 2.0

--- a/docs/djdknativersa.md
+++ b/docs/djdknativersa.md
@@ -1,5 +1,5 @@
 <!--
-* Copyright (c) 2017, 2021 IBM Corp. and others
+* Copyright (c) 2017, 2022 IBM Corp. and others
 *
 * This program and the accompanying materials are made
 * available under the terms of the Eclipse Public License 2.0

--- a/docs/dump_heapdump.md
+++ b/docs/dump_heapdump.md
@@ -1,5 +1,5 @@
 <!--
-* Copyright (c) 2017, 2021 IBM Corp. and others
+* Copyright (c) 2017, 2022 IBM Corp. and others
 *
 * This program and the accompanying materials are made
 * available under the terms of the Eclipse Public License 2.0

--- a/docs/dump_javadump.md
+++ b/docs/dump_javadump.md
@@ -1,5 +1,5 @@
 <!--
-* Copyright (c) 2017, 2021 IBM Corp. and others
+* Copyright (c) 2017, 2022 IBM Corp. and others
 *
 * This program and the accompanying materials are made
 * available under the terms of the Eclipse Public License 2.0

--- a/docs/dump_systemdump.md
+++ b/docs/dump_systemdump.md
@@ -1,5 +1,5 @@
 <!--
-* Copyright (c) 2017, 2021 IBM Corp. and others
+* Copyright (c) 2017, 2022 IBM Corp. and others
 *
 * This program and the accompanying materials are made
 * available under the terms of the Eclipse Public License 2.0

--- a/docs/env_var.md
+++ b/docs/env_var.md
@@ -1,5 +1,5 @@
 <!--
-* Copyright (c) 2017, 2021 IBM Corp. and others
+* Copyright (c) 2017, 2022 IBM Corp. and others
 *
 * This program and the accompanying materials are made
 * available under the terms of the Eclipse Public License 2.0

--- a/docs/gc.md
+++ b/docs/gc.md
@@ -1,5 +1,5 @@
 <!--
-* Copyright (c) 2017, 2021 IBM Corp. and others
+* Copyright (c) 2017, 2022 IBM Corp. and others
 *
 * This program and the accompanying materials are made
 * available under the terms of the Eclipse Public License 2.0

--- a/docs/gc_overview.md
+++ b/docs/gc_overview.md
@@ -1,5 +1,5 @@
 <!--
-* Copyright (c) 2017, 2021 IBM Corp. and others
+* Copyright (c) 2017, 2022 IBM Corp. and others
 *
 * This program and the accompanying materials are made
 * available under the terms of the Eclipse Public License 2.0

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,5 +1,5 @@
 <!--
-* Copyright (c) 2017, 2021 IBM Corp. and others
+* Copyright (c) 2017, 2022 IBM Corp. and others
 *
 * This program and the accompanying materials are made
 * available under the terms of the Eclipse Public License 2.0

--- a/docs/interface_dtfj.md
+++ b/docs/interface_dtfj.md
@@ -1,5 +1,5 @@
 ﻿<!--
-* Copyright (c) 2017, 2021 IBM Corp. and others
+* Copyright (c) 2017, 2022 IBM Corp. and others
 *
 * This program and the accompanying materials are made
 * available under the terms of the Eclipse Public License 2.0

--- a/docs/interface_jvmti.md
+++ b/docs/interface_jvmti.md
@@ -1,5 +1,5 @@
 ﻿<!--
-* Copyright (c) 2017, 2021 IBM Corp. and others
+* Copyright (c) 2017, 2022 IBM Corp. and others
 *
 * This program and the accompanying materials are made
 * available under the terms of the Eclipse Public License 2.0

--- a/docs/interface_lang_management.md
+++ b/docs/interface_lang_management.md
@@ -1,5 +1,5 @@
 <!--
-* Copyright (c) 2017, 2021 IBM Corp. and others
+* Copyright (c) 2017, 2022 IBM Corp. and others
 *
 * This program and the accompanying materials are made
 * available under the terms of the Eclipse Public License 2.0

--- a/docs/introduction.md
+++ b/docs/introduction.md
@@ -1,5 +1,5 @@
 <!--
-* Copyright (c) 2017, 2021 IBM Corp. and others
+* Copyright (c) 2017, 2022 IBM Corp. and others
 *
 * This program and the accompanying materials are made
 * available under the terms of the Eclipse Public License 2.0

--- a/docs/jit.md
+++ b/docs/jit.md
@@ -1,5 +1,5 @@
 <!--
-* Copyright (c) 2017, 2021 IBM Corp. and others
+* Copyright (c) 2017, 2022 IBM Corp. and others
 *
 * This program and the accompanying materials are made
 * available under the terms of the Eclipse Public License 2.0

--- a/docs/jitserver.md
+++ b/docs/jitserver.md
@@ -1,5 +1,5 @@
 <!--
-* Copyright (c) 2017, 2021 IBM Corp. and others
+* Copyright (c) 2017, 2022 IBM Corp. and others
 *
 * This program and the accompanying materials are made
 * available under the terms of the Eclipse Public License 2.0

--- a/docs/jitserver_tuning.md
+++ b/docs/jitserver_tuning.md
@@ -1,5 +1,5 @@
 <!--
-* Copyright (c) 2021, 2021 IBM Corp. and others
+* Copyright (c) 2017, 2022 IBM Corp. and others
 *
 * This program and the accompanying materials are made
 * available under the terms of the Eclipse Public License 2.0

--- a/docs/legal.md
+++ b/docs/legal.md
@@ -1,5 +1,5 @@
 <!--
-* Copyright (c) 2017, 2021 IBM Corp. and others
+* Copyright (c) 2017, 2022 IBM Corp. and others
 *
 * This program and the accompanying materials are made
 * available under the terms of the Eclipse Public License 2.0
@@ -38,7 +38,7 @@ See [Notices](https://github.com/eclipse-openj9/openj9-docs/blob/master/NOTICE.m
 
 Eclipse OpenJ9 documentation is subject to the following copyright:
 
-    Copyright (c) 2017, 2021 IBM Corp.
+    Copyright (c) 2017, 2022 IBM Corp.
 
 ### Trademarks
 

--- a/docs/messages_intro.md
+++ b/docs/messages_intro.md
@@ -1,5 +1,5 @@
 <!--
-* Copyright (c) 2017, 2021 IBM Corp. and others
+* Copyright (c) 2017, 2022 IBM Corp. and others
 *
 * This program and the accompanying materials are made
 * available under the terms of the Eclipse Public License 2.0

--- a/docs/openj9_defaults.md
+++ b/docs/openj9_defaults.md
@@ -1,5 +1,5 @@
 <!--
-* Copyright (c) 2017, 2021 IBM Corp. and others
+* Copyright (c) 2017, 2022 IBM Corp. and others
 *
 * This program and the accompanying materials are made
 * available under the terms of the Eclipse Public License 2.0

--- a/docs/openj9_directories.md
+++ b/docs/openj9_directories.md
@@ -1,5 +1,5 @@
 <!--
-* Copyright (c) 2017, 2021 IBM Corp. and others
+* Copyright (c) 2017, 2022 IBM Corp. and others
 *
 * This program and the accompanying materials are made
 * available under the terms of the Eclipse Public License 2.0

--- a/docs/openj9_newuser.md
+++ b/docs/openj9_newuser.md
@@ -1,5 +1,5 @@
 <!--
-* Copyright (c) 2017, 2021 IBM Corp. and others
+* Copyright (c) 2017, 2022 IBM Corp. and others
 *
 * This program and the accompanying materials are made
 * available under the terms of the Eclipse Public License 2.0

--- a/docs/openj9_releases.md
+++ b/docs/openj9_releases.md
@@ -1,5 +1,5 @@
 <!--
-* Copyright (c) 2017, 2021 IBM Corp. and others
+* Copyright (c) 2017, 2022 IBM Corp. and others
 *
 * This program and the accompanying materials are made
 * available under the terms of the Eclipse Public License 2.0

--- a/docs/openj9_signals.md
+++ b/docs/openj9_signals.md
@@ -1,5 +1,5 @@
 <!--
-* Copyright (c) 2017, 2021 IBM Corp. and others
+* Copyright (c) 2017, 2022 IBM Corp. and others
 *
 * This program and the accompanying materials are made
 * available under the terms of the Eclipse Public License 2.0

--- a/docs/shrc.md
+++ b/docs/shrc.md
@@ -1,5 +1,5 @@
 <!--
-* Copyright (c) 2017, 2021 IBM Corp. and others
+* Copyright (c) 2017, 2022 IBM Corp. and others
 *
 * This program and the accompanying materials are made
 * available under the terms of the Eclipse Public License 2.0

--- a/docs/shrc_diag_util.md
+++ b/docs/shrc_diag_util.md
@@ -1,5 +1,5 @@
 <!--
-* Copyright (c) 2017, 2021 IBM Corp. and others
+* Copyright (c) 2017, 2022 IBM Corp. and others
 *
 * This program and the accompanying materials are made
 * available under the terms of the Eclipse Public License 2.0

--- a/docs/stylesheets/oj9.css
+++ b/docs/stylesheets/oj9.css
@@ -1,5 +1,5 @@
 /*
-* Copyright (c) 2017, 2021 IBM Corp. and others
+* Copyright (c) 2017, 2022 IBM Corp. and others
 *
 * This program and the accompanying materials are made
 * available under the terms of the Eclipse Public License 2.0

--- a/docs/tool_builder.md
+++ b/docs/tool_builder.md
@@ -1,5 +1,5 @@
 ﻿<!--
-* Copyright (c) 2017, 2021 IBM Corp. and others
+* Copyright (c) 2017, 2022 IBM Corp. and others
 *
 * This program and the accompanying materials are made
 * available under the terms of the Eclipse Public License 2.0

--- a/docs/tool_jcmd.md
+++ b/docs/tool_jcmd.md
@@ -1,5 +1,5 @@
 ﻿<!--
-* Copyright (c) 2017, 2021 IBM Corp. and others
+* Copyright (c) 2017, 2022 IBM Corp. and others
 *
 * This program and the accompanying materials are made
 * available under the terms of the Eclipse Public License 2.0

--- a/docs/tool_jdmpview.md
+++ b/docs/tool_jdmpview.md
@@ -1,5 +1,5 @@
 <!--
-* Copyright (c) 2017, 2021 IBM Corp. and others
+* Copyright (c) 2017, 2022 IBM Corp. and others
 *
 * This program and the accompanying materials are made
 * available under the terms of the Eclipse Public License 2.0

--- a/docs/tool_jextract.md
+++ b/docs/tool_jextract.md
@@ -1,5 +1,5 @@
 <!--
-* Copyright (c) 2017, 2018 IBM Corp. and others
+* Copyright (c) 2017, 2022 IBM Corp. and others
 *
 * This program and the accompanying materials are made
 * available under the terms of the Eclipse Public License 2.0

--- a/docs/tool_jmap.md
+++ b/docs/tool_jmap.md
@@ -1,5 +1,5 @@
 ﻿<!--
-* Copyright (c) 2017, 2021 IBM Corp. and others
+* Copyright (c) 2017, 2022 IBM Corp. and others
 *
 * This program and the accompanying materials are made
 * available under the terms of the Eclipse Public License 2.0

--- a/docs/tool_jps.md
+++ b/docs/tool_jps.md
@@ -1,5 +1,5 @@
 ﻿<!--
-* Copyright (c) 2017, 2021 IBM Corp. and others
+* Copyright (c) 2017, 2022 IBM Corp. and others
 *
 * This program and the accompanying materials are made
 * available under the terms of the Eclipse Public License 2.0

--- a/docs/tool_jstack.md
+++ b/docs/tool_jstack.md
@@ -1,5 +1,5 @@
 ﻿<!--
-* Copyright (c) 2017, 2021 IBM Corp. and others
+* Copyright (c) 2017, 2022 IBM Corp. and others
 *
 * This program and the accompanying materials are made
 * available under the terms of the Eclipse Public License 2.0

--- a/docs/tool_jstat.md
+++ b/docs/tool_jstat.md
@@ -1,5 +1,5 @@
 ﻿<!--
-* Copyright (c) 2017, 2021 IBM Corp. and others
+* Copyright (c) 2017, 2022 IBM Corp. and others
 *
 * This program and the accompanying materials are made
 * available under the terms of the Eclipse Public License 2.0

--- a/docs/tool_migration.md
+++ b/docs/tool_migration.md
@@ -1,5 +1,5 @@
 ﻿<!--
-* Copyright (c) 2017, 2021 IBM Corp. and others
+* Copyright (c) 2017, 2022 IBM Corp. and others
 *
 * This program and the accompanying materials are made
 * available under the terms of the Eclipse Public License 2.0

--- a/docs/tool_traceformat.md
+++ b/docs/tool_traceformat.md
@@ -1,5 +1,5 @@
 <!--
-* Copyright (c) 2017, 2021 IBM Corp. and others
+* Copyright (c) 2017, 2022 IBM Corp. and others
 *
 * This program and the accompanying materials are made
 * available under the terms of the Eclipse Public License 2.0

--- a/docs/version0.10.md
+++ b/docs/version0.10.md
@@ -1,5 +1,5 @@
 <!--
-* Copyright (c) 2017, 2021 IBM Corp. and others
+* Copyright (c) 2017, 2022 IBM Corp. and others
 *
 * This program and the accompanying materials are made
 * available under the terms of the Eclipse Public License 2.0

--- a/docs/version0.11.md
+++ b/docs/version0.11.md
@@ -1,5 +1,5 @@
 <!--
-* Copyright (c) 2017, 2021 IBM Corp. and others
+* Copyright (c) 2017, 2022 IBM Corp. and others
 *
 * This program and the accompanying materials are made
 * available under the terms of the Eclipse Public License 2.0

--- a/docs/version0.12.md
+++ b/docs/version0.12.md
@@ -1,5 +1,5 @@
 <!--
-* Copyright (c) 2017, 2021 IBM Corp. and others
+* Copyright (c) 2017, 2022 IBM Corp. and others
 *
 * This program and the accompanying materials are made
 * available under the terms of the Eclipse Public License 2.0

--- a/docs/version0.13.md
+++ b/docs/version0.13.md
@@ -1,5 +1,5 @@
 <!--
-* Copyright (c) 2017, 2021 IBM Corp. and others
+* Copyright (c) 2017, 2022 IBM Corp. and others
 *
 * This program and the accompanying materials are made
 * available under the terms of the Eclipse Public License 2.0

--- a/docs/version0.14.md
+++ b/docs/version0.14.md
@@ -1,5 +1,5 @@
 <!--
-* Copyright (c) 2017, 2021 IBM Corp. and others
+* Copyright (c) 2017, 2022 IBM Corp. and others
 *
 * This program and the accompanying materials are made
 * available under the terms of the Eclipse Public License 2.0

--- a/docs/version0.15.md
+++ b/docs/version0.15.md
@@ -1,5 +1,5 @@
 <!--
-* Copyright (c) 2017, 2021 IBM Corp. and others
+* Copyright (c) 2017, 2022 IBM Corp. and others
 *
 * This program and the accompanying materials are made
 * available under the terms of the Eclipse Public License 2.0

--- a/docs/version0.16.md
+++ b/docs/version0.16.md
@@ -1,5 +1,5 @@
 <!--
-* Copyright (c) 2017, 2021 IBM Corp. and others
+* Copyright (c) 2017, 2022 IBM Corp. and others
 *
 * This program and the accompanying materials are made
 * available under the terms of the Eclipse Public License 2.0

--- a/docs/version0.17.md
+++ b/docs/version0.17.md
@@ -1,5 +1,5 @@
 <!--
-* Copyright (c) 2017, 2021 IBM Corp. and others
+* Copyright (c) 2017, 2022 IBM Corp. and others
 *
 * This program and the accompanying materials are made
 * available under the terms of the Eclipse Public License 2.0

--- a/docs/version0.18.md
+++ b/docs/version0.18.md
@@ -1,5 +1,5 @@
 <!--
-* Copyright (c) 2017, 2021 IBM Corp. and others
+* Copyright (c) 2017, 2022 IBM Corp. and others
 *
 * This program and the accompanying materials are made
 * available under the terms of the Eclipse Public License 2.0

--- a/docs/version0.19.md
+++ b/docs/version0.19.md
@@ -1,5 +1,5 @@
 <!--
-* Copyright (c) 2017, 2021 IBM Corp. and others
+* Copyright (c) 2017, 2022 IBM Corp. and others
 *
 * This program and the accompanying materials are made
 * available under the terms of the Eclipse Public License 2.0

--- a/docs/version0.20.md
+++ b/docs/version0.20.md
@@ -1,5 +1,5 @@
 <!--
-* Copyright (c) 2017, 2021 IBM Corp. and others
+* Copyright (c) 2017, 2022 IBM Corp. and others
 *
 * This program and the accompanying materials are made
 * available under the terms of the Eclipse Public License 2.0

--- a/docs/version0.21.md
+++ b/docs/version0.21.md
@@ -1,5 +1,5 @@
 <!--
-* Copyright (c) 2017, 2021 IBM Corp. and others
+* Copyright (c) 2017, 2022 IBM Corp. and others
 *
 * This program and the accompanying materials are made
 * available under the terms of the Eclipse Public License 2.0

--- a/docs/version0.22.md
+++ b/docs/version0.22.md
@@ -1,5 +1,5 @@
 <!--
-* Copyright (c) 2017, 2021 IBM Corp. and others
+* Copyright (c) 2017, 2022 IBM Corp. and others
 *
 * This program and the accompanying materials are made
 * available under the terms of the Eclipse Public License 2.0

--- a/docs/version0.23.md
+++ b/docs/version0.23.md
@@ -1,5 +1,5 @@
 <!--
-* Copyright (c) 2017, 2021 IBM Corp. and others
+* Copyright (c) 2017, 2022 IBM Corp. and others
 *
 * This program and the accompanying materials are made
 * available under the terms of the Eclipse Public License 2.0

--- a/docs/version0.24.md
+++ b/docs/version0.24.md
@@ -1,5 +1,5 @@
 <!--
-* Copyright (c) 2017, 2021 IBM Corp. and others
+* Copyright (c) 2017, 2022 IBM Corp. and others
 *
 * This program and the accompanying materials are made
 * available under the terms of the Eclipse Public License 2.0

--- a/docs/version0.25.md
+++ b/docs/version0.25.md
@@ -1,5 +1,5 @@
 <!--
-* Copyright (c) 2017, 2021 IBM Corp. and others
+* Copyright (c) 2017, 2022 IBM Corp. and others
 *
 * This program and the accompanying materials are made
 * available under the terms of the Eclipse Public License 2.0

--- a/docs/version0.26.md
+++ b/docs/version0.26.md
@@ -1,5 +1,5 @@
 <!--
-* Copyright (c) 2017, 2021 IBM Corp. and others
+* Copyright (c) 2017, 2022 IBM Corp. and others
 *
 * This program and the accompanying materials are made
 * available under the terms of the Eclipse Public License 2.0

--- a/docs/version0.27.md
+++ b/docs/version0.27.md
@@ -1,5 +1,5 @@
 <!--
-* Copyright (c) 2017, 2021 IBM Corp. and others
+* Copyright (c) 2017, 2022 IBM Corp. and others
 *
 * This program and the accompanying materials are made
 * available under the terms of the Eclipse Public License 2.0

--- a/docs/version0.29.1.md
+++ b/docs/version0.29.1.md
@@ -1,5 +1,5 @@
 <!--
-* Copyright (c) 2021, 2021 IBM Corp. and others
+* Copyright (c) 2017, 2022 IBM Corp. and others
 *
 * This program and the accompanying materials are made
 * available under the terms of the Eclipse Public License 2.0

--- a/docs/version0.29.md
+++ b/docs/version0.29.md
@@ -1,5 +1,5 @@
 <!--
-* Copyright (c) 2021, 2021 IBM Corp. and others
+* Copyright (c) 2017, 2022 IBM Corp. and others
 *
 * This program and the accompanying materials are made
 * available under the terms of the Eclipse Public License 2.0

--- a/docs/version0.30.md
+++ b/docs/version0.30.md
@@ -1,5 +1,5 @@
 <!--
-* Copyright (c) 2021, 2022 IBM Corp. and others
+* Copyright (c) 2017, 2022 IBM Corp. and others
 *
 * This program and the accompanying materials are made
 * available under the terms of the Eclipse Public License 2.0

--- a/docs/version0.8.md
+++ b/docs/version0.8.md
@@ -1,5 +1,5 @@
 <!--
-* Copyright (c) 2017, 2021 IBM Corp. and others
+* Copyright (c) 2017, 2022 IBM Corp. and others
 *
 * This program and the accompanying materials are made
 * available under the terms of the Eclipse Public License 2.0

--- a/docs/version0.9.md
+++ b/docs/version0.9.md
@@ -1,5 +1,5 @@
 <!--
-* Copyright (c) 2017, 2021 IBM Corp. and others
+* Copyright (c) 2017, 2022 IBM Corp. and others
 *
 * This program and the accompanying materials are made
 * available under the terms of the Eclipse Public License 2.0

--- a/docs/vgclog.md
+++ b/docs/vgclog.md
@@ -1,5 +1,5 @@
 <!--
-* Copyright (c) 2017, 2021 IBM Corp. and others
+* Copyright (c) 2017, 2022 IBM Corp. and others
 *
 * This program and the accompanying materials are made
 * available under the terms of the Eclipse Public License 2.0

--- a/docs/vgclog_examples.md
+++ b/docs/vgclog_examples.md
@@ -1,5 +1,5 @@
 <!--
-* Copyright (c) 2017, 2021 IBM Corp. and others
+* Copyright (c) 2017, 2022 IBM Corp. and others
 *
 * This program and the accompanying materials are made
 * available under the terms of the Eclipse Public License 2.0

--- a/docs/x.md
+++ b/docs/x.md
@@ -1,5 +1,5 @@
 <!--
-* Copyright (c) 2017, 2021 IBM Corp. and others
+* Copyright (c) 2017, 2022 IBM Corp. and others
 *
 * This program and the accompanying materials are made
 * available under the terms of the Eclipse Public License 2.0

--- a/docs/x_jvm_commands.md
+++ b/docs/x_jvm_commands.md
@@ -1,5 +1,5 @@
 <!--
-* Copyright (c) 2017, 2021 IBM Corp. and others
+* Copyright (c) 2017, 2022 IBM Corp. and others
 *
 * This program and the accompanying materials are made
 * available under the terms of the Eclipse Public License 2.0

--- a/docs/xaggressive.md
+++ b/docs/xaggressive.md
@@ -1,5 +1,5 @@
 <!--
-* Copyright (c) 2017, 2021 IBM Corp. and others
+* Copyright (c) 2017, 2022 IBM Corp. and others
 *
 * This program and the accompanying materials are made
 * available under the terms of the Eclipse Public License 2.0

--- a/docs/xalwaysclassgc.md
+++ b/docs/xalwaysclassgc.md
@@ -1,5 +1,5 @@
 <!--
-* Copyright (c) 2017, 2021 IBM Corp. and others
+* Copyright (c) 2017, 2022 IBM Corp. and others
 *
 * This program and the accompanying materials are made
 * available under the terms of the Eclipse Public License 2.0

--- a/docs/xaot.md
+++ b/docs/xaot.md
@@ -1,5 +1,5 @@
 <!--
-* Copyright (c) 2017, 2021 IBM Corp. and others
+* Copyright (c) 2017, 2022 IBM Corp. and others
 *
 * This program and the accompanying materials are made
 * available under the terms of the Eclipse Public License 2.0

--- a/docs/xargencoding.md
+++ b/docs/xargencoding.md
@@ -1,5 +1,5 @@
 <!--
-* Copyright (c) 2017, 2021 IBM Corp. and others
+* Copyright (c) 2017, 2022 IBM Corp. and others
 *
 * This program and the accompanying materials are made
 * available under the terms of the Eclipse Public License 2.0

--- a/docs/xbootclasspath.md
+++ b/docs/xbootclasspath.md
@@ -1,5 +1,5 @@
 <!--
-* Copyright (c) 2017, 2021 IBM Corp. and others
+* Copyright (c) 2017, 2022 IBM Corp. and others
 *
 * This program and the accompanying materials are made
 * available under the terms of the Eclipse Public License 2.0

--- a/docs/xceehdlr.md
+++ b/docs/xceehdlr.md
@@ -1,5 +1,5 @@
 <!--
-* Copyright (c) 2017, 2021 IBM Corp. and others
+* Copyright (c) 2017, 2022 IBM Corp. and others
 *
 * This program and the accompanying materials are made
 * available under the terms of the Eclipse Public License 2.0

--- a/docs/xcheck.md
+++ b/docs/xcheck.md
@@ -1,5 +1,5 @@
 ﻿<!--
-* Copyright (c) 2017, 2021 IBM Corp. and others
+* Copyright (c) 2017, 2022 IBM Corp. and others
 *
 * This program and the accompanying materials are made
 * available under the terms of the Eclipse Public License 2.0

--- a/docs/xclassgc.md
+++ b/docs/xclassgc.md
@@ -1,5 +1,5 @@
 <!--
-* Copyright (c) 2017, 2021 IBM Corp. and others
+* Copyright (c) 2017, 2022 IBM Corp. and others
 *
 * This program and the accompanying materials are made
 * available under the terms of the Eclipse Public License 2.0

--- a/docs/xcodecache.md
+++ b/docs/xcodecache.md
@@ -1,5 +1,5 @@
 <!--
-* Copyright (c) 2017, 2021 IBM Corp. and others
+* Copyright (c) 2017, 2022 IBM Corp. and others
 *
 * This program and the accompanying materials are made
 * available under the terms of the Eclipse Public License 2.0

--- a/docs/xcodecachetotal.md
+++ b/docs/xcodecachetotal.md
@@ -1,5 +1,5 @@
 <!--
-* Copyright (c) 2017, 2021 IBM Corp. and others
+* Copyright (c) 2017, 2022 IBM Corp. and others
 *
 * This program and the accompanying materials are made
 * available under the terms of the Eclipse Public License 2.0

--- a/docs/xcomp.md
+++ b/docs/xcomp.md
@@ -1,5 +1,5 @@
 <!--
-* Copyright (c) 2017, 2021 IBM Corp. and others
+* Copyright (c) 2017, 2022 IBM Corp. and others
 *
 * This program and the accompanying materials are made
 * available under the terms of the Eclipse Public License 2.0

--- a/docs/xcompactexplicitgc.md
+++ b/docs/xcompactexplicitgc.md
@@ -1,5 +1,5 @@
 <!--
-* Copyright (c) 2017, 2021 IBM Corp. and others
+* Copyright (c) 2017, 2022 IBM Corp. and others
 *
 * This program and the accompanying materials are made
 * available under the terms of the Eclipse Public License 2.0

--- a/docs/xcompactgc.md
+++ b/docs/xcompactgc.md
@@ -1,5 +1,5 @@
 <!--
-* Copyright (c) 2017, 2021 IBM Corp. and others
+* Copyright (c) 2017, 2022 IBM Corp. and others
 *
 * This program and the accompanying materials are made
 * available under the terms of the Eclipse Public License 2.0

--- a/docs/xcompilationthreads.md
+++ b/docs/xcompilationthreads.md
@@ -1,5 +1,5 @@
 <!--
-* Copyright (c) 2017, 2021 IBM Corp. and others
+* Copyright (c) 2017, 2022 IBM Corp. and others
 *
 * This program and the accompanying materials are made
 * available under the terms of the Eclipse Public License 2.0

--- a/docs/xcompressedrefs.md
+++ b/docs/xcompressedrefs.md
@@ -1,5 +1,5 @@
 <!--
-* Copyright (c) 2017, 2021 IBM Corp. and others
+* Copyright (c) 2017, 2022 IBM Corp. and others
 *
 * This program and the accompanying materials are made
 * available under the terms of the Eclipse Public License 2.0

--- a/docs/xconcurrentbackground.md
+++ b/docs/xconcurrentbackground.md
@@ -1,5 +1,5 @@
 <!--
-* Copyright (c) 2017, 2021 IBM Corp. and others
+* Copyright (c) 2017, 2022 IBM Corp. and others
 *
 * This program and the accompanying materials are made
 * available under the terms of the Eclipse Public License 2.0

--- a/docs/xconcurrentlevel.md
+++ b/docs/xconcurrentlevel.md
@@ -1,5 +1,5 @@
 <!--
-* Copyright (c) 2017, 2021 IBM Corp. and others
+* Copyright (c) 2017, 2022 IBM Corp. and others
 *
 * This program and the accompanying materials are made
 * available under the terms of the Eclipse Public License 2.0

--- a/docs/xconcurrentslack.md
+++ b/docs/xconcurrentslack.md
@@ -1,5 +1,5 @@
 <!--
-* Copyright (c) 2017, 2021 IBM Corp. and others
+* Copyright (c) 2017, 2022 IBM Corp. and others
 *
 * This program and the accompanying materials are made
 * available under the terms of the Eclipse Public License 2.0

--- a/docs/xconmeter.md
+++ b/docs/xconmeter.md
@@ -1,5 +1,5 @@
 <!--
-* Copyright (c) 2017, 2021 IBM Corp. and others
+* Copyright (c) 2017, 2022 IBM Corp. and others
 *
 * This program and the accompanying materials are made
 * available under the terms of the Eclipse Public License 2.0

--- a/docs/xdisablejavadump.md
+++ b/docs/xdisablejavadump.md
@@ -1,5 +1,5 @@
 <!--
-* Copyright (c) 2017, 2021 IBM Corp. and others
+* Copyright (c) 2017, 2022 IBM Corp. and others
 *
 * This program and the accompanying materials are made
 * available under the terms of the Eclipse Public License 2.0

--- a/docs/xdump.md
+++ b/docs/xdump.md
@@ -1,5 +1,5 @@
 <!--
-* Copyright (c) 2017, 2021 IBM Corp. and others
+* Copyright (c) 2017, 2022 IBM Corp. and others
 *
 * This program and the accompanying materials are made
 * available under the terms of the Eclipse Public License 2.0

--- a/docs/xenableexcessivegc.md
+++ b/docs/xenableexcessivegc.md
@@ -1,5 +1,5 @@
 <!--
-* Copyright (c) 2017, 2021 IBM Corp. and others
+* Copyright (c) 2017, 2022 IBM Corp. and others
 *
 * This program and the accompanying materials are made
 * available under the terms of the Eclipse Public License 2.0

--- a/docs/xenableexplicitgc.md
+++ b/docs/xenableexplicitgc.md
@@ -1,5 +1,5 @@
 <!--
-* Copyright (c) 2017, 2021 IBM Corp. and others
+* Copyright (c) 2017, 2022 IBM Corp. and others
 *
 * This program and the accompanying materials are made
 * available under the terms of the Eclipse Public License 2.0

--- a/docs/xenablestringconstantgc.md
+++ b/docs/xenablestringconstantgc.md
@@ -1,5 +1,5 @@
 <!--
-* Copyright (c) 2017, 2021 IBM Corp. and others
+* Copyright (c) 2017, 2022 IBM Corp. and others
 *
 * This program and the accompanying materials are made
 * available under the terms of the Eclipse Public License 2.0

--- a/docs/xfastresolve.md
+++ b/docs/xfastresolve.md
@@ -1,5 +1,5 @@
 <!--
-* Copyright (c) 2017, 2021 IBM Corp. and others
+* Copyright (c) 2017, 2022 IBM Corp. and others
 *
 * This program and the accompanying materials are made
 * available under the terms of the Eclipse Public License 2.0

--- a/docs/xfuture.md
+++ b/docs/xfuture.md
@@ -1,5 +1,5 @@
 <!--
-* Copyright (c) 2017, 2021 IBM Corp. and others
+* Copyright (c) 2017, 2022 IBM Corp. and others
 *
 * This program and the accompanying materials are made
 * available under the terms of the Eclipse Public License 2.0

--- a/docs/xgc.md
+++ b/docs/xgc.md
@@ -1,5 +1,5 @@
 <!--
-* Copyright (c) 2017, 2021 IBM Corp. and others
+* Copyright (c) 2017, 2022 IBM Corp. and others
 *
 * This program and the accompanying materials are made
 * available under the terms of the Eclipse Public License 2.0

--- a/docs/xgcmaxthreads.md
+++ b/docs/xgcmaxthreads.md
@@ -1,5 +1,5 @@
 <!--
-* Copyright (c) 2017, 2021 IBM Corp. and others
+* Copyright (c) 2017, 2022 IBM Corp. and others
 *
 * This program and the accompanying materials are made
 * available under the terms of the Eclipse Public License 2.0

--- a/docs/xgcpolicy.md
+++ b/docs/xgcpolicy.md
@@ -1,5 +1,5 @@
 <!--
-* Copyright (c) 2017, 2021 IBM Corp. and others
+* Copyright (c) 2017, 2022 IBM Corp. and others
 *
 * This program and the accompanying materials are made
 * available under the terms of the Eclipse Public License 2.0

--- a/docs/xgcsplitheap.md
+++ b/docs/xgcsplitheap.md
@@ -1,5 +1,5 @@
 <!--
-* Copyright (c) 2017, 2021 IBM Corp. and others
+* Copyright (c) 2017, 2022 IBM Corp. and others
 *
 * This program and the accompanying materials are made
 * available under the terms of the Eclipse Public License 2.0

--- a/docs/xgcthreads.md
+++ b/docs/xgcthreads.md
@@ -1,5 +1,5 @@
 <!--
-* Copyright (c) 2017, 2021 IBM Corp. and others
+* Copyright (c) 2017, 2022 IBM Corp. and others
 *
 * This program and the accompanying materials are made
 * available under the terms of the Eclipse Public License 2.0

--- a/docs/xgcworkpackets.md
+++ b/docs/xgcworkpackets.md
@@ -1,5 +1,5 @@
 <!--
-* Copyright (c) 2017, 2021 IBM Corp. and others
+* Copyright (c) 2017, 2022 IBM Corp. and others
 *
 * This program and the accompanying materials are made
 * available under the terms of the Eclipse Public License 2.0

--- a/docs/xint.md
+++ b/docs/xint.md
@@ -1,5 +1,5 @@
 <!--
-* Copyright (c) 2017, 2021 IBM Corp. and others
+* Copyright (c) 2017, 2022 IBM Corp. and others
 *
 * This program and the accompanying materials are made
 * available under the terms of the Eclipse Public License 2.0

--- a/docs/xjit.md
+++ b/docs/xjit.md
@@ -1,5 +1,5 @@
 <!--
-* Copyright (c) 2017, 2021 IBM Corp. and others
+* Copyright (c) 2017, 2022 IBM Corp. and others
 *
 * This program and the accompanying materials are made
 * available under the terms of the Eclipse Public License 2.0

--- a/docs/xjni.md
+++ b/docs/xjni.md
@@ -1,5 +1,5 @@
 <!--
-* Copyright (c) 2017, 2021 IBM Corp. and others
+* Copyright (c) 2017, 2022 IBM Corp. and others
 *
 * This program and the accompanying materials are made
 * available under the terms of the Eclipse Public License 2.0

--- a/docs/xlinenumbers.md
+++ b/docs/xlinenumbers.md
@@ -1,5 +1,5 @@
 <!--
-* Copyright (c) 2017, 2021 IBM Corp. and others
+* Copyright (c) 2017, 2022 IBM Corp. and others
 *
 * This program and the accompanying materials are made
 * available under the terms of the Eclipse Public License 2.0

--- a/docs/xloa.md
+++ b/docs/xloa.md
@@ -1,5 +1,5 @@
 <!--
-* Copyright (c) 2017, 2021 IBM Corp. and others
+* Copyright (c) 2017, 2022 IBM Corp. and others
 *
 * This program and the accompanying materials are made
 * available under the terms of the Eclipse Public License 2.0

--- a/docs/xloaminimum.md
+++ b/docs/xloaminimum.md
@@ -1,5 +1,5 @@
 <!--
-* Copyright (c) 2017, 2021 IBM Corp. and others
+* Copyright (c) 2017, 2022 IBM Corp. and others
 *
 * This program and the accompanying materials are made
 * available under the terms of the Eclipse Public License 2.0

--- a/docs/xlockreservation.md
+++ b/docs/xlockreservation.md
@@ -1,5 +1,5 @@
 <!--
-* Copyright (c) 2017, 2021 IBM Corp. and others
+* Copyright (c) 2017, 2022 IBM Corp. and others
 *
 * This program and the accompanying materials are made
 * available under the terms of the Eclipse Public License 2.0

--- a/docs/xlockword.md
+++ b/docs/xlockword.md
@@ -1,5 +1,5 @@
 <!--
-* Copyright (c) 2017, 2021 IBM Corp. and others
+* Copyright (c) 2017, 2022 IBM Corp. and others
 *
 * This program and the accompanying materials are made
 * available under the terms of the Eclipse Public License 2.0

--- a/docs/xlog.md
+++ b/docs/xlog.md
@@ -1,5 +1,5 @@
 <!--
-* Copyright (c) 2017, 2021 IBM Corp. and others
+* Copyright (c) 2017, 2022 IBM Corp. and others
 *
 * This program and the accompanying materials are made
 * available under the terms of the Eclipse Public License 2.0

--- a/docs/xlp.md
+++ b/docs/xlp.md
@@ -1,5 +1,5 @@
 <!--
-* Copyright (c) 2017, 2021 IBM Corp. and others
+* Copyright (c) 2017, 2022 IBM Corp. and others
 *
 * This program and the accompanying materials are made
 * available under the terms of the Eclipse Public License 2.0

--- a/docs/xlpcodecache.md
+++ b/docs/xlpcodecache.md
@@ -1,5 +1,5 @@
 <!--
-* Copyright (c) 2017, 2021 IBM Corp. and others
+* Copyright (c) 2017, 2022 IBM Corp. and others
 *
 * This program and the accompanying materials are made
 * available under the terms of the Eclipse Public License 2.0

--- a/docs/xlpobjectheap.md
+++ b/docs/xlpobjectheap.md
@@ -1,5 +1,5 @@
 <!--
-* Copyright (c) 2017, 2021 IBM Corp. and others
+* Copyright (c) 2017, 2022 IBM Corp. and others
 *
 * This program and the accompanying materials are made
 * available under the terms of the Eclipse Public License 2.0

--- a/docs/xmca.md
+++ b/docs/xmca.md
@@ -1,5 +1,5 @@
 <!--
-* Copyright (c) 2017, 2021 IBM Corp. and others
+* Copyright (c) 2017, 2022 IBM Corp. and others
 *
 * This program and the accompanying materials are made
 * available under the terms of the Eclipse Public License 2.0

--- a/docs/xmcrs.md
+++ b/docs/xmcrs.md
@@ -1,5 +1,5 @@
 <!--
-* Copyright (c) 2017, 2021 IBM Corp. and others
+* Copyright (c) 2017, 2022 IBM Corp. and others
 *
 * This program and the accompanying materials are made
 * available under the terms of the Eclipse Public License 2.0

--- a/docs/xmine.md
+++ b/docs/xmine.md
@@ -1,5 +1,5 @@
 <!--
-* Copyright (c) 2017, 2021 IBM Corp. and others
+* Copyright (c) 2017, 2022 IBM Corp. and others
 *
 * This program and the accompanying materials are made
 * available under the terms of the Eclipse Public License 2.0

--- a/docs/xminf.md
+++ b/docs/xminf.md
@@ -1,5 +1,5 @@
 <!--
-* Copyright (c) 2017, 2021 IBM Corp. and others
+* Copyright (c) 2017, 2022 IBM Corp. and others
 *
 * This program and the accompanying materials are made
 * available under the terms of the Eclipse Public License 2.0

--- a/docs/xmint.md
+++ b/docs/xmint.md
@@ -1,5 +1,5 @@
 <!--
-* Copyright (c) 2017, 2021 IBM Corp. and others
+* Copyright (c) 2017, 2022 IBM Corp. and others
 *
 * This program and the accompanying materials are made
 * available under the terms of the Eclipse Public License 2.0

--- a/docs/xmn.md
+++ b/docs/xmn.md
@@ -1,5 +1,5 @@
 <!--
-* Copyright (c) 2017, 2021 IBM Corp. and others
+* Copyright (c) 2017, 2022 IBM Corp. and others
 *
 * This program and the accompanying materials are made
 * available under the terms of the Eclipse Public License 2.0

--- a/docs/xmo.md
+++ b/docs/xmo.md
@@ -1,5 +1,5 @@
 <!--
-* Copyright (c) 2017, 2021 IBM Corp. and others
+* Copyright (c) 2017, 2022 IBM Corp. and others
 *
 * This program and the accompanying materials are made
 * available under the terms of the Eclipse Public License 2.0

--- a/docs/xmoi.md
+++ b/docs/xmoi.md
@@ -1,5 +1,5 @@
 <!--
-* Copyright (c) 2017, 2021 IBM Corp. and others
+* Copyright (c) 2017, 2022 IBM Corp. and others
 *
 * This program and the accompanying materials are made
 * available under the terms of the Eclipse Public License 2.0

--- a/docs/xmr.md
+++ b/docs/xmr.md
@@ -1,5 +1,5 @@
 <!--
-* Copyright (c) 2017, 2021 IBM Corp. and others
+* Copyright (c) 2017, 2022 IBM Corp. and others
 *
 * This program and the accompanying materials are made
 * available under the terms of the Eclipse Public License 2.0

--- a/docs/xms.md
+++ b/docs/xms.md
@@ -1,5 +1,5 @@
 <!--
-* Copyright (c) 2017, 2021 IBM Corp. and others
+* Copyright (c) 2017, 2022 IBM Corp. and others
 *
 * This program and the accompanying materials are made
 * available under the terms of the Eclipse Public License 2.0

--- a/docs/xmso.md
+++ b/docs/xmso.md
@@ -1,5 +1,5 @@
 <!--
-* Copyright (c) 2017, 2021 IBM Corp. and others
+* Copyright (c) 2017, 2022 IBM Corp. and others
 *
 * This program and the accompanying materials are made
 * available under the terms of the Eclipse Public License 2.0

--- a/docs/xnumanone.md
+++ b/docs/xnumanone.md
@@ -1,5 +1,5 @@
 <!--
-* Copyright (c) 2017, 2021 IBM Corp. and others
+* Copyright (c) 2017, 2022 IBM Corp. and others
 *
 * This program and the accompanying materials are made
 * available under the terms of the Eclipse Public License 2.0

--- a/docs/xoptionsfile.md
+++ b/docs/xoptionsfile.md
@@ -1,5 +1,5 @@
 <!--
-* Copyright (c) 2017, 2021 IBM Corp. and others
+* Copyright (c) 2017, 2022 IBM Corp. and others
 *
 * This program and the accompanying materials are made
 * available under the terms of the Eclipse Public License 2.0

--- a/docs/xquickstart.md
+++ b/docs/xquickstart.md
@@ -1,5 +1,5 @@
 <!--
-* Copyright (c) 2017, 2021 IBM Corp. and others
+* Copyright (c) 2017, 2022 IBM Corp. and others
 *
 * This program and the accompanying materials are made
 * available under the terms of the Eclipse Public License 2.0

--- a/docs/xrs.md
+++ b/docs/xrs.md
@@ -1,5 +1,5 @@
 <!--
-* Copyright (c) 2017, 2021 IBM Corp. and others
+* Copyright (c) 2017, 2022 IBM Corp. and others
 *
 * This program and the accompanying materials are made
 * available under the terms of the Eclipse Public License 2.0

--- a/docs/xsamplingexpirationtime.md
+++ b/docs/xsamplingexpirationtime.md
@@ -1,5 +1,5 @@
 <!--
-* Copyright (c) 2017, 2021 IBM Corp. and others
+* Copyright (c) 2017, 2022 IBM Corp. and others
 *
 * This program and the accompanying materials are made
 * available under the terms of the Eclipse Public License 2.0

--- a/docs/xscdmx.md
+++ b/docs/xscdmx.md
@@ -1,5 +1,5 @@
 <!--
-* Copyright (c) 2017, 2021 IBM Corp. and others
+* Copyright (c) 2017, 2022 IBM Corp. and others
 *
 * This program and the accompanying materials are made
 * available under the terms of the Eclipse Public License 2.0

--- a/docs/xscminaot.md
+++ b/docs/xscminaot.md
@@ -1,5 +1,5 @@
 <!--
-* Copyright (c) 2017, 2021 IBM Corp. and others
+* Copyright (c) 2017, 2022 IBM Corp. and others
 *
 * This program and the accompanying materials are made
 * available under the terms of the Eclipse Public License 2.0

--- a/docs/xscminjitdata.md
+++ b/docs/xscminjitdata.md
@@ -1,5 +1,5 @@
 <!--
-* Copyright (c) 2017, 2021 IBM Corp. and others
+* Copyright (c) 2017, 2022 IBM Corp. and others
 *
 * This program and the accompanying materials are made
 * available under the terms of the Eclipse Public License 2.0

--- a/docs/xscmx.md
+++ b/docs/xscmx.md
@@ -1,5 +1,5 @@
 <!--
-* Copyright (c) 2017, 2021 IBM Corp. and others
+* Copyright (c) 2017, 2022 IBM Corp. and others
 *
 * This program and the accompanying materials are made
 * available under the terms of the Eclipse Public License 2.0

--- a/docs/xshareclasses.md
+++ b/docs/xshareclasses.md
@@ -1,5 +1,5 @@
 ﻿<!--
-* Copyright (c) 2017, 2021 IBM Corp. and others
+* Copyright (c) 2017, 2022 IBM Corp. and others
 *
 * This program and the accompanying materials are made
 * available under the terms of the Eclipse Public License 2.0

--- a/docs/xsigcatch.md
+++ b/docs/xsigcatch.md
@@ -1,5 +1,5 @@
 <!--
-* Copyright (c) 2017, 2021 IBM Corp. and others
+* Copyright (c) 2017, 2022 IBM Corp. and others
 *
 * This program and the accompanying materials are made
 * available under the terms of the Eclipse Public License 2.0

--- a/docs/xsigchain.md
+++ b/docs/xsigchain.md
@@ -1,5 +1,5 @@
 <!--
-* Copyright (c) 2017, 2021 IBM Corp. and others
+* Copyright (c) 2017, 2022 IBM Corp. and others
 *
 * This program and the accompanying materials are made
 * available under the terms of the Eclipse Public License 2.0

--- a/docs/xsignal.md
+++ b/docs/xsignal.md
@@ -1,5 +1,5 @@
 ﻿<!--
-* Copyright (c) 2017, 2021 IBM Corp. and others
+* Copyright (c) 2017, 2022 IBM Corp. and others
 *
 * This program and the accompanying materials are made
 * available under the terms of the Eclipse Public License 2.0

--- a/docs/xsoftmx.md
+++ b/docs/xsoftmx.md
@@ -1,5 +1,5 @@
 <!--
-* Copyright (c) 2017, 2021 IBM Corp. and others
+* Copyright (c) 2017, 2022 IBM Corp. and others
 *
 * This program and the accompanying materials are made
 * available under the terms of the Eclipse Public License 2.0

--- a/docs/xsoftrefthreshold.md
+++ b/docs/xsoftrefthreshold.md
@@ -1,5 +1,5 @@
 <!--
-* Copyright (c) 2017, 2021 IBM Corp. and others
+* Copyright (c) 2017, 2022 IBM Corp. and others
 *
 * This program and the accompanying materials are made
 * available under the terms of the Eclipse Public License 2.0

--- a/docs/xss.md
+++ b/docs/xss.md
@@ -1,5 +1,5 @@
 <!--
-* Copyright (c) 2017, 2021 IBM Corp. and others
+* Copyright (c) 2017, 2022 IBM Corp. and others
 *
 * This program and the accompanying materials are made
 * available under the terms of the Eclipse Public License 2.0

--- a/docs/xsyslog.md
+++ b/docs/xsyslog.md
@@ -1,5 +1,5 @@
 <!--
-* Copyright (c) 2017, 2021 IBM Corp. and others
+* Copyright (c) 2017, 2022 IBM Corp. and others
 *
 * This program and the accompanying materials are made
 * available under the terms of the Eclipse Public License 2.0

--- a/docs/xtgc.md
+++ b/docs/xtgc.md
@@ -1,5 +1,5 @@
 <!--
-* Copyright (c) 2017, 2021 IBM Corp. and others
+* Copyright (c) 2017, 2022 IBM Corp. and others
 *
 * This program and the accompanying materials are made
 * available under the terms of the Eclipse Public License 2.0

--- a/docs/xthr.md
+++ b/docs/xthr.md
@@ -1,5 +1,5 @@
 <!--
-* Copyright (c) 2017, 2021 IBM Corp. and others
+* Copyright (c) 2017, 2022 IBM Corp. and others
 *
 * This program and the accompanying materials are made
 * available under the terms of the Eclipse Public License 2.0

--- a/docs/xtlhprefetch.md
+++ b/docs/xtlhprefetch.md
@@ -1,5 +1,5 @@
 <!--
-* Copyright (c) 2017, 2021 IBM Corp. and others
+* Copyright (c) 2017, 2022 IBM Corp. and others
 *
 * This program and the accompanying materials are made
 * available under the terms of the Eclipse Public License 2.0

--- a/docs/xtrace.md
+++ b/docs/xtrace.md
@@ -1,5 +1,5 @@
 <!--
-* Copyright (c) 2017, 2021 IBM Corp. and others
+* Copyright (c) 2017, 2022 IBM Corp. and others
 *
 * This program and the accompanying materials are made
 * available under the terms of the Eclipse Public License 2.0

--- a/docs/xtunevirtualized.md
+++ b/docs/xtunevirtualized.md
@@ -1,5 +1,5 @@
 <!--
-* Copyright (c) 2017, 2021 IBM Corp. and others
+* Copyright (c) 2017, 2022 IBM Corp. and others
 *
 * This program and the accompanying materials are made
 * available under the terms of the Eclipse Public License 2.0

--- a/docs/xverbosegclog.md
+++ b/docs/xverbosegclog.md
@@ -1,5 +1,5 @@
 <!--
-* Copyright (c) 2017, 2021 IBM Corp. and others
+* Copyright (c) 2017, 2022 IBM Corp. and others
 *
 * This program and the accompanying materials are made
 * available under the terms of the Eclipse Public License 2.0

--- a/docs/xverify.md
+++ b/docs/xverify.md
@@ -1,5 +1,5 @@
 <!--
-* Copyright (c) 2017, 2021 IBM Corp. and others
+* Copyright (c) 2017, 2022 IBM Corp. and others
 *
 * This program and the accompanying materials are made
 * available under the terms of the Eclipse Public License 2.0

--- a/docs/xx_jvm_commands.md
+++ b/docs/xx_jvm_commands.md
@@ -1,5 +1,5 @@
 <!--
-* Copyright (c) 2017, 2021 IBM Corp. and others
+* Copyright (c) 2017, 2022 IBM Corp. and others
 *
 * This program and the accompanying materials are made
 * available under the terms of the Eclipse Public License 2.0

--- a/docs/xxactiveprocessorcount.md
+++ b/docs/xxactiveprocessorcount.md
@@ -1,5 +1,5 @@
 <!--
-* Copyright (c) 2017, 2021 IBM Corp. and others
+* Copyright (c) 2017, 2022 IBM Corp. and others
 *
 * This program and the accompanying materials are made
 * available under the terms of the Eclipse Public License 2.0

--- a/docs/xxadaptivegcthreading.md
+++ b/docs/xxadaptivegcthreading.md
@@ -1,5 +1,5 @@
 <!--
-* Copyright (c) 2017, 2021 IBM Corp. and others
+* Copyright (c) 2017, 2022 IBM Corp. and others
 *
 * This program and the accompanying materials are made
 * available under the terms of the Eclipse Public License 2.0

--- a/docs/xxallowvmshutdown.md
+++ b/docs/xxallowvmshutdown.md
@@ -1,5 +1,5 @@
 <!--
-* Copyright (c) 2017, 2021 IBM Corp. and others
+* Copyright (c) 2017, 2022 IBM Corp. and others
 *
 * This program and the accompanying materials are made
 * available under the terms of the Eclipse Public License 2.0

--- a/docs/xxalwayspretouch.md
+++ b/docs/xxalwayspretouch.md
@@ -1,5 +1,5 @@
 <!--
-* Copyright (c) 2017, 2021 IBM Corp. and others
+* Copyright (c) 2017, 2022 IBM Corp. and others
 *
 * This program and the accompanying materials are made
 * available under the terms of the Eclipse Public License 2.0

--- a/docs/xxclassrelationshipverifier.md
+++ b/docs/xxclassrelationshipverifier.md
@@ -1,5 +1,5 @@
 <!--
-* Copyright (c) 2017, 2021 IBM Corp. and others
+* Copyright (c) 2017, 2022 IBM Corp. and others
 *
 * This program and the accompanying materials are made
 * available under the terms of the Eclipse Public License 2.0

--- a/docs/xxcodecachetotal.md
+++ b/docs/xxcodecachetotal.md
@@ -1,5 +1,5 @@
 <!--
-* Copyright (c) 2017, 2021 IBM Corp. and others
+* Copyright (c) 2017, 2022 IBM Corp. and others
 *
 * This program and the accompanying materials are made
 * available under the terms of the Eclipse Public License 2.0

--- a/docs/xxcompactstrings.md
+++ b/docs/xxcompactstrings.md
@@ -1,5 +1,5 @@
 ﻿<!--
-* Copyright (c) 2017, 2021 IBM Corp. and others
+* Copyright (c) 2017, 2022 IBM Corp. and others
 *
 * This program and the accompanying materials are made
 * available under the terms of the Eclipse Public License 2.0

--- a/docs/xxconcgcthreads.md
+++ b/docs/xxconcgcthreads.md
@@ -1,5 +1,5 @@
 <!--
-* Copyright (c) 2017, 2021 IBM Corp. and others
+* Copyright (c) 2017, 2022 IBM Corp. and others
 *
 * This program and the accompanying materials are made
 * available under the terms of the Eclipse Public License 2.0

--- a/docs/xxdiagnosesynconvaluebasedclasses.md
+++ b/docs/xxdiagnosesynconvaluebasedclasses.md
@@ -1,5 +1,5 @@
 <!--
-* Copyright (c) 2021, 2021 IBM Corp. and others
+* Copyright (c) 2017, 2022 IBM Corp. and others
 *
 * This program and the accompanying materials are made
 * available under the terms of the Eclipse Public License 2.0

--- a/docs/xxdisableexplicitgc.md
+++ b/docs/xxdisableexplicitgc.md
@@ -1,5 +1,5 @@
 ﻿<!--
-* Copyright (c) 2017, 2021 IBM Corp. and others
+* Copyright (c) 2017, 2022 IBM Corp. and others
 *
 * This program and the accompanying materials are made
 * available under the terms of the Eclipse Public License 2.0

--- a/docs/xxdisclaimjitscratch.md
+++ b/docs/xxdisclaimjitscratch.md
@@ -1,5 +1,5 @@
 <!--
-* Copyright (c) 2017, 2021 IBM Corp. and others
+* Copyright (c) 2017, 2022 IBM Corp. and others
 *
 * This program and the accompanying materials are made
 * available under the terms of the Eclipse Public License 2.0

--- a/docs/xxenable3164interoperability.md
+++ b/docs/xxenable3164interoperability.md
@@ -1,5 +1,5 @@
 ﻿<!--
-* Copyright (c) 2021, 2021 IBM Corp. and others
+* Copyright (c) 2017, 2022 IBM Corp. and others
 *
 * This program and the accompanying materials are made
 * available under the terms of the Eclipse Public License 2.0

--- a/docs/xxenablecpumonitor.md
+++ b/docs/xxenablecpumonitor.md
@@ -1,5 +1,5 @@
 <!--
-* Copyright (c) 2017, 2021 IBM Corp. and others
+* Copyright (c) 2017, 2022 IBM Corp. and others
 *
 * This program and the accompanying materials are made
 * available under the terms of the Eclipse Public License 2.0

--- a/docs/xxensurehashed.md
+++ b/docs/xxensurehashed.md
@@ -1,5 +1,5 @@
 <!--
-* Copyright (c) 2021, 2021 IBM Corp. and others
+* Copyright (c) 2017, 2022 IBM Corp. and others
 *
 * This program and the accompanying materials are made
 * available under the terms of the Eclipse Public License 2.0

--- a/docs/xxexitonoutofmemoryerror.md
+++ b/docs/xxexitonoutofmemoryerror.md
@@ -1,5 +1,5 @@
 ﻿<!--
-* Copyright (c) 2017, 2021 IBM Corp. and others
+* Copyright (c) 2017, 2022 IBM Corp. and others
 *
 * This program and the accompanying materials are made
 * available under the terms of the Eclipse Public License 2.0

--- a/docs/xxgloballockreservation.md
+++ b/docs/xxgloballockreservation.md
@@ -1,5 +1,5 @@
 <!--
-* Copyright (c) 2017, 2021 IBM Corp. and others
+* Copyright (c) 2017, 2022 IBM Corp. and others
 *
 * This program and the accompanying materials are made
 * available under the terms of the Eclipse Public License 2.0

--- a/docs/xxhandlesigabrt.md
+++ b/docs/xxhandlesigabrt.md
@@ -1,5 +1,5 @@
 <!--
-* Copyright (c) 2017, 2021 IBM Corp. and others
+* Copyright (c) 2017, 2022 IBM Corp. and others
 *
 * This program and the accompanying materials are made
 * available under the terms of the Eclipse Public License 2.0

--- a/docs/xxhandlesigxfsz.md
+++ b/docs/xxhandlesigxfsz.md
@@ -1,5 +1,5 @@
 <!--
-* Copyright (c) 2017, 2021 IBM Corp. and others
+* Copyright (c) 2017, 2022 IBM Corp. and others
 *
 * This program and the accompanying materials are made
 * available under the terms of the Eclipse Public License 2.0

--- a/docs/xxheapdumponoutofmemory.md
+++ b/docs/xxheapdumponoutofmemory.md
@@ -1,5 +1,5 @@
 ﻿<!--
-* Copyright (c) 2017, 2021 IBM Corp. and others
+* Copyright (c) 2017, 2022 IBM Corp. and others
 *
 * This program and the accompanying materials are made
 * available under the terms of the Eclipse Public License 2.0

--- a/docs/xxheapdumppath.md
+++ b/docs/xxheapdumppath.md
@@ -1,5 +1,5 @@
 ﻿<!--
-* Copyright (c) 2017, 2021 IBM Corp. and others
+* Copyright (c) 2017, 2022 IBM Corp. and others
 *
 * This program and the accompanying materials are made
 * available under the terms of the Eclipse Public License 2.0

--- a/docs/xxheapmanagementmxbeancompatibility.md
+++ b/docs/xxheapmanagementmxbeancompatibility.md
@@ -1,5 +1,5 @@
 <!--
-* Copyright (c) 2017, 2021 IBM Corp. and others
+* Copyright (c) 2017, 2022 IBM Corp. and others
 *
 * This program and the accompanying materials are made
 * available under the terms of the Eclipse Public License 2.0

--- a/docs/xxidletuningcompactonidle.md
+++ b/docs/xxidletuningcompactonidle.md
@@ -1,5 +1,5 @@
 <!--
-* Copyright (c) 2017, 2021 IBM Corp. and others
+* Copyright (c) 2017, 2022 IBM Corp. and others
 *
 * This program and the accompanying materials are made
 * available under the terms of the Eclipse Public License 2.0

--- a/docs/xxidletuninggconidle.md
+++ b/docs/xxidletuninggconidle.md
@@ -1,5 +1,5 @@
 <!--
-* Copyright (c) 2017, 2021 IBM Corp. and others
+* Copyright (c) 2017, 2022 IBM Corp. and others
 *
 * This program and the accompanying materials are made
 * available under the terms of the Eclipse Public License 2.0

--- a/docs/xxidletuningminfreeheaponidle.md
+++ b/docs/xxidletuningminfreeheaponidle.md
@@ -1,5 +1,5 @@
 <!--
-* Copyright (c) 2017, 2021 IBM Corp. and others
+* Copyright (c) 2017, 2022 IBM Corp. and others
 *
 * This program and the accompanying materials are made
 * available under the terms of the Eclipse Public License 2.0

--- a/docs/xxidletuningminidlewaittime.md
+++ b/docs/xxidletuningminidlewaittime.md
@@ -1,5 +1,5 @@
 <!--
-* Copyright (c) 2017, 2021 IBM Corp. and others
+* Copyright (c) 2017, 2022 IBM Corp. and others
 *
 * This program and the accompanying materials are made
 * available under the terms of the Eclipse Public License 2.0

--- a/docs/xxignoreunrecognizedvmoptions.md
+++ b/docs/xxignoreunrecognizedvmoptions.md
@@ -1,5 +1,5 @@
 <!--
-* Copyright (c) 2017, 2021 IBM Corp. and others
+* Copyright (c) 2017, 2022 IBM Corp. and others
 *
 * This program and the accompanying materials are made
 * available under the terms of the Eclipse Public License 2.0

--- a/docs/xxignoreunrecognizedxxcolonoptions.md
+++ b/docs/xxignoreunrecognizedxxcolonoptions.md
@@ -1,5 +1,5 @@
 <!--
-* Copyright (c) 2017, 2021 IBM Corp. and others
+* Copyright (c) 2017, 2022 IBM Corp. and others
 *
 * This program and the accompanying materials are made
 * available under the terms of the Eclipse Public License 2.0

--- a/docs/xxinitialheapsize.md
+++ b/docs/xxinitialheapsize.md
@@ -1,5 +1,5 @@
 ﻿<!--
-* Copyright (c) 2017, 2021 IBM Corp. and others
+* Copyright (c) 2017, 2022 IBM Corp. and others
 *
 * This program and the accompanying materials are made
 * available under the terms of the Eclipse Public License 2.0

--- a/docs/xxinitialrampercentage.md
+++ b/docs/xxinitialrampercentage.md
@@ -1,5 +1,5 @@
 <!--
-* Copyright (c) 2017, 2021 IBM Corp. and others
+* Copyright (c) 2017, 2022 IBM Corp. and others
 *
 * This program and the accompanying materials are made
 * available under the terms of the Eclipse Public License 2.0

--- a/docs/xxinterleavememory.md
+++ b/docs/xxinterleavememory.md
@@ -1,5 +1,5 @@
 <!--
-* Copyright (c) 2017, 2021 IBM Corp. and others
+* Copyright (c) 2017, 2022 IBM Corp. and others
 *
 * This program and the accompanying materials are made
 * available under the terms of the Eclipse Public License 2.0

--- a/docs/xxjitinlinewatches.md
+++ b/docs/xxjitinlinewatches.md
@@ -1,5 +1,5 @@
 ﻿<!--
-* Copyright (c) 2017, 2021 IBM Corp. and others
+* Copyright (c) 2017, 2022 IBM Corp. and others
 *
 * This program and the accompanying materials are made
 * available under the terms of the Eclipse Public License 2.0

--- a/docs/xxjitserveraddress.md
+++ b/docs/xxjitserveraddress.md
@@ -1,5 +1,5 @@
 <!--
-* Copyright (c) 2021, 2021 IBM Corp. and others
+* Copyright (c) 2017, 2022 IBM Corp. and others
 *
 * This program and the accompanying materials are made
 * available under the terms of the Eclipse Public License 2.0

--- a/docs/xxjitserverlocalsynccompiles.md
+++ b/docs/xxjitserverlocalsynccompiles.md
@@ -1,5 +1,5 @@
 <!--
-* Copyright (c) 2021, 2021 IBM Corp. and others
+* Copyright (c) 2017, 2022 IBM Corp. and others
 *
 * This program and the accompanying materials are made
 * available under the terms of the Eclipse Public License 2.0

--- a/docs/xxjitserverlogconnections.md
+++ b/docs/xxjitserverlogconnections.md
@@ -1,5 +1,5 @@
 <!--
-* Copyright (c) 2021, 2021 IBM Corp. and others
+* Copyright (c) 2017, 2022 IBM Corp. and others
 *
 * This program and the accompanying materials are made
 * available under the terms of the Eclipse Public License 2.0

--- a/docs/xxjitserverport.md
+++ b/docs/xxjitserverport.md
@@ -1,5 +1,5 @@
 <!--
-* Copyright (c) 2021, 2021 IBM Corp. and others
+* Copyright (c) 2017, 2022 IBM Corp. and others
 *
 * This program and the accompanying materials are made
 * available under the terms of the Eclipse Public License 2.0

--- a/docs/xxjitservershareromclasses.md
+++ b/docs/xxjitservershareromclasses.md
@@ -1,5 +1,5 @@
 <!--
-* Copyright (c) 2021, 2021 IBM Corp. and others
+* Copyright (c) 2017, 2022 IBM Corp. and others
 *
 * This program and the accompanying materials are made
 * available under the terms of the Eclipse Public License 2.0

--- a/docs/xxjitserversslcert.md
+++ b/docs/xxjitserversslcert.md
@@ -1,5 +1,5 @@
 <!--
-* Copyright (c) 2021, 2021 IBM Corp. and others
+* Copyright (c) 2017, 2022 IBM Corp. and others
 *
 * This program and the accompanying materials are made
 * available under the terms of the Eclipse Public License 2.0

--- a/docs/xxjitservertimeout.md
+++ b/docs/xxjitservertimeout.md
@@ -1,5 +1,5 @@
 <!--
-* Copyright (c) 2021, 2021 IBM Corp. and others
+* Copyright (c) 2017, 2022 IBM Corp. and others
 *
 * This program and the accompanying materials are made
 * available under the terms of the Eclipse Public License 2.0

--- a/docs/xxlazysymbolresolution.md
+++ b/docs/xxlazysymbolresolution.md
@@ -1,5 +1,5 @@
 <!--
-* Copyright (c) 2017, 2021 IBM Corp. and others
+* Copyright (c) 2017, 2022 IBM Corp. and others
 *
 * This program and the accompanying materials are made
 * available under the terms of the Eclipse Public License 2.0

--- a/docs/xxlegacyxlogoption.md
+++ b/docs/xxlegacyxlogoption.md
@@ -1,5 +1,5 @@
 ﻿<!--
-* Copyright (c) 2017, 2021 IBM Corp. and others
+* Copyright (c) 2017, 2022 IBM Corp. and others
 *
 * This program and the accompanying materials are made
 * available under the terms of the Eclipse Public License 2.0

--- a/docs/xxmaxdirectmemorysize.md
+++ b/docs/xxmaxdirectmemorysize.md
@@ -1,5 +1,5 @@
 <!--
-* Copyright (c) 2017, 2021 IBM Corp. and others
+* Copyright (c) 2017, 2022 IBM Corp. and others
 *
 * This program and the accompanying materials are made
 * available under the terms of the Eclipse Public License 2.0

--- a/docs/xxnosuballoc32bitmem.md
+++ b/docs/xxnosuballoc32bitmem.md
@@ -1,5 +1,5 @@
 <!--
-* Copyright (c) 2017, 2021 IBM Corp. and others
+* Copyright (c) 2017, 2022 IBM Corp. and others
 *
 * This program and the accompanying materials are made
 * available under the terms of the Eclipse Public License 2.0

--- a/docs/xxonoutofmemoryerror.md
+++ b/docs/xxonoutofmemoryerror.md
@@ -1,5 +1,5 @@
 <!--
-* Copyright (c) 2017, 2021 IBM Corp. and others
+* Copyright (c) 2017, 2022 IBM Corp. and others
 *
 * This program and the accompanying materials are made
 * available under the terms of the Eclipse Public License 2.0

--- a/docs/xxoriginaljdk8heapsizecompatibilitymode.md
+++ b/docs/xxoriginaljdk8heapsizecompatibilitymode.md
@@ -1,5 +1,5 @@
 <!--
-* Copyright (c) 2017, 2021 IBM Corp. and others
+* Copyright (c) 2017, 2022 IBM Corp. and others
 *
 * This program and the accompanying materials are made
 * available under the terms of the Eclipse Public License 2.0

--- a/docs/xxpagealigndirectmemory.md
+++ b/docs/xxpagealigndirectmemory.md
@@ -1,5 +1,5 @@
 <!--
-* Copyright (c) 2017, 2021 IBM Corp. and others
+* Copyright (c) 2017, 2022 IBM Corp. and others
 *
 * This program and the accompanying materials are made
 * available under the terms of the Eclipse Public License 2.0

--- a/docs/xxparallelcmsthreads.md
+++ b/docs/xxparallelcmsthreads.md
@@ -1,5 +1,5 @@
 <!--
-* Copyright (c) 2017, 2021 IBM Corp. and others
+* Copyright (c) 2017, 2022 IBM Corp. and others
 *
 * This program and the accompanying materials are made
 * available under the terms of the Eclipse Public License 2.0

--- a/docs/xxparallelgcmaxthreads.md
+++ b/docs/xxparallelgcmaxthreads.md
@@ -1,5 +1,5 @@
 <!--
-* Copyright (c) 2017, 2021 IBM Corp. and others
+* Copyright (c) 2017, 2022 IBM Corp. and others
 *
 * This program and the accompanying materials are made
 * available under the terms of the Eclipse Public License 2.0

--- a/docs/xxparallelgcthreads.md
+++ b/docs/xxparallelgcthreads.md
@@ -1,5 +1,5 @@
 <!--
-* Copyright (c) 2017, 2021 IBM Corp. and others
+* Copyright (c) 2017, 2022 IBM Corp. and others
 *
 * This program and the accompanying materials are made
 * available under the terms of the Eclipse Public License 2.0

--- a/docs/xxportablesharedcache.md
+++ b/docs/xxportablesharedcache.md
@@ -1,5 +1,5 @@
 <!--
-* Copyright (c) 2017, 2021 IBM Corp. and others
+* Copyright (c) 2017, 2022 IBM Corp. and others
 *
 * This program and the accompanying materials are made
 * available under the terms of the Eclipse Public License 2.0

--- a/docs/xxpositiveidentityhash.md
+++ b/docs/xxpositiveidentityhash.md
@@ -1,5 +1,5 @@
 <!--
-* Copyright (c) 2017, 2021 IBM Corp. and others
+* Copyright (c) 2017, 2022 IBM Corp. and others
 *
 * This program and the accompanying materials are made
 * available under the terms of the Eclipse Public License 2.0

--- a/docs/xxprintcodecache.md
+++ b/docs/xxprintcodecache.md
@@ -1,5 +1,5 @@
 <!--
-* Copyright (c) 2017, 2021 IBM Corp. and others
+* Copyright (c) 2017, 2022 IBM Corp. and others
 *
 * This program and the accompanying materials are made
 * available under the terms of the Eclipse Public License 2.0

--- a/docs/xxprintflagsfinal.md
+++ b/docs/xxprintflagsfinal.md
@@ -1,5 +1,5 @@
 <!--
-* Copyright (c) 2017, 2021 IBM Corp. and others
+* Copyright (c) 2017, 2022 IBM Corp. and others
 *
 * This program and the accompanying materials are made
 * available under the terms of the Eclipse Public License 2.0

--- a/docs/xxreadipinfoforras.md
+++ b/docs/xxreadipinfoforras.md
@@ -1,5 +1,5 @@
 ﻿<!--
-* Copyright (c) 2017, 2021 IBM Corp. and others
+* Copyright (c) 2017, 2022 IBM Corp. and others
 *
 * This program and the accompanying materials are made
 * available under the terms of the Eclipse Public License 2.0

--- a/docs/xxreducecpumonitoroverhead.md
+++ b/docs/xxreducecpumonitoroverhead.md
@@ -1,5 +1,5 @@
 <!--
-* Copyright (c) 2017, 2021 IBM Corp. and others
+* Copyright (c) 2017, 2022 IBM Corp. and others
 *
 * This program and the accompanying materials are made
 * available under the terms of the Eclipse Public License 2.0

--- a/docs/xxrequirejitserver.md
+++ b/docs/xxrequirejitserver.md
@@ -1,5 +1,5 @@
 <!--
-* Copyright (c) 2021, 2021 IBM Corp. and others
+* Copyright (c) 2017, 2022 IBM Corp. and others
 *
 * This program and the accompanying materials are made
 * available under the terms of the Eclipse Public License 2.0

--- a/docs/xxruntimeinstrumentation.md
+++ b/docs/xxruntimeinstrumentation.md
@@ -1,5 +1,5 @@
 <!--
-* Copyright (c) 2017, 2021 IBM Corp. and others
+* Copyright (c) 2017, 2022 IBM Corp. and others
 *
 * This program and the accompanying materials are made
 * available under the terms of the Eclipse Public License 2.0

--- a/docs/xxsethwprefetch.md
+++ b/docs/xxsethwprefetch.md
@@ -1,5 +1,5 @@
 <!--
-* Copyright (c) 2017, 2021 IBM Corp. and others
+* Copyright (c) 2017, 2022 IBM Corp. and others
 *
 * This program and the accompanying materials are made
 * available under the terms of the Eclipse Public License 2.0

--- a/docs/xxshareanonymousclasses.md
+++ b/docs/xxshareanonymousclasses.md
@@ -1,5 +1,5 @@
 <!--
-* Copyright (c) 2017, 2021 IBM Corp. and others
+* Copyright (c) 2017, 2022 IBM Corp. and others
 *
 * This program and the accompanying materials are made
 * available under the terms of the Eclipse Public License 2.0

--- a/docs/xxshareclassesenablebci.md
+++ b/docs/xxshareclassesenablebci.md
@@ -1,5 +1,5 @@
 <!--
-* Copyright (c) 2017, 2021 IBM Corp. and others
+* Copyright (c) 2017, 2022 IBM Corp. and others
 *
 * This program and the accompanying materials are made
 * available under the terms of the Eclipse Public License 2.0

--- a/docs/xxsharedcachehardlimit.md
+++ b/docs/xxsharedcachehardlimit.md
@@ -1,5 +1,5 @@
 <!--
-* Copyright (c) 2017, 2021 IBM Corp. and others
+* Copyright (c) 2017, 2022 IBM Corp. and others
 *
 * This program and the accompanying materials are made
 * available under the terms of the Eclipse Public License 2.0

--- a/docs/xxshareunsafeclasses.md
+++ b/docs/xxshareunsafeclasses.md
@@ -1,5 +1,5 @@
 <!--
-* Copyright (c) 2017, 2021 IBM Corp. and others
+* Copyright (c) 2017, 2022 IBM Corp. and others
 *
 * This program and the accompanying materials are made
 * available under the terms of the Eclipse Public License 2.0

--- a/docs/xxstacktraceinthrowable.md
+++ b/docs/xxstacktraceinthrowable.md
@@ -1,5 +1,5 @@
 <!--
-* Copyright (c) 2017, 2021 IBM Corp. and others
+* Copyright (c) 2017, 2022 IBM Corp. and others
 *
 * This program and the accompanying materials are made
 * available under the terms of the Eclipse Public License 2.0

--- a/docs/xxtransparenthugepage.md
+++ b/docs/xxtransparenthugepage.md
@@ -1,5 +1,5 @@
 <!--
-* Copyright (c) 2017, 2021 IBM Corp. and others
+* Copyright (c) 2017, 2022 IBM Corp. and others
 *
 * This program and the accompanying materials are made
 * available under the terms of the Eclipse Public License 2.0

--- a/docs/xxusecompressedoops.md
+++ b/docs/xxusecompressedoops.md
@@ -1,5 +1,5 @@
 <!--
-* Copyright (c) 2017, 2021 IBM Corp. and others
+* Copyright (c) 2017, 2022 IBM Corp. and others
 *
 * This program and the accompanying materials are made
 * available under the terms of the Eclipse Public License 2.0

--- a/docs/xxusecontainersupport.md
+++ b/docs/xxusecontainersupport.md
@@ -1,5 +1,5 @@
 <!--
-* Copyright (c) 2017, 2021 IBM Corp. and others
+* Copyright (c) 2017, 2022 IBM Corp. and others
 *
 * This program and the accompanying materials are made
 * available under the terms of the Eclipse Public License 2.0

--- a/docs/xxusegcstartuphints.md
+++ b/docs/xxusegcstartuphints.md
@@ -1,5 +1,5 @@
 <!--
-* Copyright (c) 2017, 2021 IBM Corp. and others
+* Copyright (c) 2017, 2022 IBM Corp. and others
 *
 * This program and the accompanying materials are made
 * available under the terms of the Eclipse Public License 2.0

--- a/docs/xxusejitserver.md
+++ b/docs/xxusejitserver.md
@@ -1,5 +1,5 @@
 <!--
-* Copyright (c) 2021, 2021 IBM Corp. and others
+* Copyright (c) 2017, 2022 IBM Corp. and others
 *
 * This program and the accompanying materials are made
 * available under the terms of the Eclipse Public License 2.0

--- a/docs/xxusenogc.md
+++ b/docs/xxusenogc.md
@@ -1,5 +1,5 @@
 <!--
-* Copyright (c) 2017, 2021 IBM Corp. and others
+* Copyright (c) 2017, 2022 IBM Corp. and others
 *
 * This program and the accompanying materials are made
 * available under the terms of the Eclipse Public License 2.0

--- a/docs/xxutfcache.md
+++ b/docs/xxutfcache.md
@@ -1,5 +1,5 @@
 <!--
-* Copyright (c) 2021, 2021 IBM Corp. and others
+* Copyright (c) 2017, 2022 IBM Corp. and others
 *
 * This program and the accompanying materials are made
 * available under the terms of the Eclipse Public License 2.0

--- a/docs/xxverboseverification.md
+++ b/docs/xxverboseverification.md
@@ -1,5 +1,5 @@
 <!--
-* Copyright (c) 2017, 2021 IBM Corp. and others
+* Copyright (c) 2017, 2022 IBM Corp. and others
 *
 * This program and the accompanying materials are made
 * available under the terms of the Eclipse Public License 2.0

--- a/docs/xxvmlockclassloader.md
+++ b/docs/xxvmlockclassloader.md
@@ -1,5 +1,5 @@
 <!--
-* Copyright (c) 2017, 2021 IBM Corp. and others
+* Copyright (c) 2017, 2022 IBM Corp. and others
 *
 * This program and the accompanying materials are made
 * available under the terms of the Eclipse Public License 2.0

--- a/docs/xzero.md
+++ b/docs/xzero.md
@@ -1,5 +1,5 @@
 <!--
-* Copyright (c) 2017, 2021 IBM Corp. and others
+* Copyright (c) 2017, 2022 IBM Corp. and others
 *
 * This program and the accompanying materials are made
 * available under the terms of the Eclipse Public License 2.0

--- a/jenkinsFile_cleanup_staging.groovy
+++ b/jenkinsFile_cleanup_staging.groovy
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2021 IBM Corp. and others
+ * Copyright (c) 2017, 2022 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,4 +1,4 @@
-# Copyright (c) 2017, 2021 IBM Corp. and others
+# Copyright (c) 2017, 2022 IBM Corp. and others
 #
 # This program and the accompanying materials are made
 # available under the terms of the Eclipse Public License 2.0

--- a/theme/base_simple.html
+++ b/theme/base_simple.html
@@ -1,5 +1,5 @@
 <!--
-* Copyright (c) 2017, 2021 IBM Corp. and others
+* Copyright (c) 2017, 2022 IBM Corp. and others
 *
 * This program and the accompanying materials are made
 * available under the terms of the Eclipse Public License 2.0

--- a/theme/partials/footer.html
+++ b/theme/partials/footer.html
@@ -1,5 +1,5 @@
 <!--
-* Copyright (c) 2017, 2021 IBM Corp. and others
+* Copyright (c) 2017, 2022 IBM Corp. and others
 *
 * This program and the accompanying materials are made
 * available under the terms of the Eclipse Public License 2.0

--- a/theme/partials/languages/en_custom.html
+++ b/theme/partials/languages/en_custom.html
@@ -1,5 +1,5 @@
 <!--
-* Copyright (c) 2017, 2021 IBM Corp. and others
+* Copyright (c) 2017, 2022 IBM Corp. and others
 *
 * This program and the accompanying materials are made
 * available under the terms of the Eclipse Public License 2.0


### PR DESCRIPTION
* Update copyright year to 2022

Closes: #882

Cherry pick of https://github.com/eclipse-openj9/openj9-docs/pull/885 (i.e. https://github.com/eclipse-openj9/openj9-docs/commit/0685d17a78d) for the 0.30 branch. 885 was merged using "Squash and merge".

Signed-off-by: Esther <doveye@uk.ibm.com>