### PR TITLE
Update 0.30 branch with missing docs

### DIFF
--- a/docs/version0.30.md
+++ b/docs/version0.30.md
@@ -30,6 +30,7 @@ The following new features and notable changes since version 0.29.0 are included
 - [Changes to the shared classes cache generation number](#changes-to-the-shared-classes-cache-generation-number)
 - [Ignored options now captured in java dumps](#ignored-options-captured-in-java-dumps)
 - [New `-XX:[+|-]EnsureHashed` option added](#new-xx-ensurehashed-option-added)
+- [Redesigned heap resizing for balanced GC policy](#redesigned-heap-resizing-for-balanced-gc-policy)
 
 ## Features and changes
 
@@ -59,6 +60,30 @@ would yield the following in the <tt>ENVINFO</tt> section after the complete lis
 ### New `-XX:[+|-]EnsureHashed` option added
 
 This option specifies/unspecifies classes of objects that will be hashed and extended with a hash slot upon object creation or first move. This option may improve performance for applications that frequently hash objects of a certain type. See [-XX:[+|-]EnsureHashed](xxensurehashed.md) for more details.
+
+### Redesigned heap resizing for balanced GC policy
+
+Heap resizing heuristics have been redesigned for balanced GC. This includes both total heap resizing including Eden and non-Eden components indenpendantly, and also balancing between these two components when heap is fully expanded. The heuristics now combine both CPU overhead (for both Partial GCs and Global Mark Phase) and heap occupancy criteria. The balancing between Eden and non-Eden for fully expanded heaps is far more dynamic (instead of being mostly fixed to ratio 1:4).
+
+As a consequence there should typically be less need for heap sizing tuning options, most notably for Eden sizing options [-Xmn/mns/mnx](xmn.md). 
+
+Also, a new soft limit pause target is added for Partial GCs, that defaults to 200ms. This criteria is combined with PGC CPU overhead critera for a balanced compromise between minimizing footprint, maximizing throughput and meeting the paused time target.
+
+More details about the new heurstics can be found at:
+
+[https://blog.openj9.org/2021/09/24/balanced-gc-performance-improvements-eden-heap-sizing-improvements/](https://blog.openj9.org/2021/09/24/balanced-gc-performance-improvements-eden-heap-sizing-improvements/)
+
+The heuristcs now obey existing options
+
+[-Xmint/-Xmaxt](xmint.md) and <br /> 
+[-Xgc:dnssExpectedTimeRatioMaximum/Minimum](xgc.md#dnssexpectedtimeratiomaximum)
+
+previously used for optthruput/optavgpause/gencon GC policies and also
+
+[-Xgc:targetPausetime](xgc.md#targetpausetime)
+
+previosly used only for Metronome GC policy.
+
 
 ## Known problems and full release information
 

--- a/docs/xgc.md
+++ b/docs/xgc.md
@@ -53,7 +53,7 @@ Options that change the behavior of the garbage collector.
 | [`scvTenureAge`                     ](#scvtenureage                     ) | Sets the initial scavenger tenure age in the generational concurrent GC policy.                           |
 | [`stdGlobalCompactToSatisfyAllocate`](#stdglobalcompacttosatisfyallocate) | Prevents the GC from performing a compaction unless absolutely required.                                  |
 | [`synchronousGCOnOOM`               ](#synchronousgconoom               )     | Stops an application to allow GC activity.                                                                             |
-| [`targetPausetime`                  ](#targetpausetime                  )   | Sets the GC pause time for the `metronome` GC policy.                                                   |
+| [`targetPausetime`                  ](#targetpausetime                  )   | Sets the target GC pause time for the `metronome` and `balanced` GC policies.                            |
 | [`targetUtilization`                ](#targetutilization                )   | Sets application utilization for the `metronome` GC policy.                                                   |
 | [`tlhIncrementSize`                 ](#tlhincrementsize                 ) | Sets the size of the thread local heap (TLH) increment.                                                   |
 | [`tlhInitialSize`                   ](#tlhinitialsize                   ) | Sets the initial size of the thread local heap.                                                           |
@@ -286,9 +286,15 @@ the dynamic compaction triggers that look at heap occupancy. This option works o
 
         -Xgc:targetPausetime=N
 
-: Sets the GC pause time, where `N` is the time in milliseconds. When this option is specified, the garbage collector operates with pauses that do not exceed the value specified. If this option is not specified the default pause time is set to 3 milliseconds. For example, running with `-Xgc:targetPausetime=20` causes the garbage collector to pause for no longer than 20 milliseconds during GC operations.
+: Sets the target GC pause time, where `N` is the time in milliseconds.
 
-: This option applies only to the `metronome` GC policy.
+: When this option is specified with the `metronome` policy, the garbage collector operates with pauses that do not exceed the value specified. If this option is not specified when using the `metronome` policy, the default pause time target is set to 3 milliseconds. For example, running with `-Xgc:targetPausetime=20` causes the garbage collector to pause for no longer than 20 milliseconds during GC operations.
+
+: When this option is specified with the `balanced` policy, the GC will use the specified pause time as a *soft* pause time target. If this option is not specified when using the `balanced` policy, the default pause time target is set to 200 milliseconds. If the GC pauses are longer than the specified target, then the GC may shrink the amount of eden regions in order to satisfy the target pause time. If the percentage of time spent in PGC pauses is higher than `dnssExpectedTimeRatioMaximum` *and* the GC pauses are longer than the specified pause time target, then the target pause time may not be satisfied, in order to balance reaching the target pause time goal and percentage of time in GC pause goal.
+
+    :fontawesome-solid-pencil-alt:{: .note aria-hidden="true"} **Note:** Specifying an ultra low `targetPausetime` with the Balanced GC policy may cause the percentage of time spent in GC pauses to noticeably increase.
+
+: This option applies only to the `metronome` and `balanced` GC policies.
 
 ### `targetUtilization`
 

--- a/docs/xgc.md
+++ b/docs/xgc.md
@@ -38,8 +38,8 @@ Options that change the behavior of the garbage collector.
 | [`classUnloadingKickoffThreshold`   ](#classunloadingkickoffthreshold   ) | Sets a threshold to start an early concurrent global garbage collection (GC) cycle due to recent, heavy class loading activity  |
 | [`classUnloadingThreshold`          ](#classunloadingthreshold          ) | Sets a threshold to trigger a class unloading operation in a global GC cycle                                     |
 | [`concurrentScavenge`               ](#concurrentscavenge               ) | Enables a GC mode with less pause times.                                             |
-| [`dnssExpectedTimeRatioMaximum`     ](#dnssexpectedtimeratiomaximum     ) | Sets the maximum time to spend on GC of the nursery area.                                                 |
-| [`dnssExpectedTimeRatioMinimum`     ](#dnssexpectedtimeratiominimum     ) | Sets the minimum time to spend on GC of the nursery area.                                                 |
+| [`dnssExpectedTimeRatioMaximum`     ](#dnssexpectedtimeratiomaximum     ) | Sets the maximum percentage of time to spend on local GC pauses                                             |
+| [`dnssExpectedTimeRatioMinimum`     ](#dnssexpectedtimeratiominimum     ) | Sets the minimum percentage of time to spend on local GC pauses                                             |
 | [`dynamicBreadthFirstScanOrdering`  ](#dynamicbreadthfirstscanordering  ) | Sets scan mode to dynamic breadth first.                                             |
 | [`excessiveGCratio`                 ](#excessivegcratio                 ) | Sets a boundary value beyond which GC is deemed to be excessive.                                          |
 | [`hierarchicalScanOrdering`         ](#hierarchicalscanordering         ) | Sets scan mode to hierarchical.                                             |
@@ -124,25 +124,25 @@ Options that change the behavior of the garbage collector.
 
         -Xgc:dnssExpectedTimeRatioMaximum=<value>
 
-: | Setting       | Value          | Default               |
-  |---------------|----------------|-----------------------|
-  | `<value>`     | [percentage]   | 5                     |
+: | Setting       | Value          | Default                       |
+  |---------------|----------------|-------------------------------|
+  | `<value>`     | [percentage]   | 5 for gencon, 5 for balanced  |
 
-: The maximum amount of time spent on garbage collection of the nursery area, expressed as a percentage of the overall time for the last three GC intervals.
+: The maximum percentage of time spent in local garbage collection pauses. For the `gencon` policy, this refers to the amount of time spent on the nursery area of the heap (scavenge operation). For the `balanced` policy, this refers to the amount of time spent on the eden regions of the heap (PGC operation).
 
-: This option applies only to the `gencon` GC policy.
+: This option applies only to the `gencon` and `balanced` GC policies.
 
 ### `dnssExpectedTimeRatioMinimum`
 
         -Xgc:dnssExpectedTimeRatioMinimum=<value>
 
-: | Setting       | Value          | Default               |
-  |---------------|----------------|-----------------------|
-  | `<value>`     | [percentage]   | 1                     |
+: | Setting       | Value          | Default                      |
+  |---------------|----------------|------------------------------|
+  | `<value>`     | [percentage]   | 1 for gencon, 2 for balanced |
 
-: The minimum amount of time spent on garbage collection of the nursery area, expressed as a percentage of the overall time for the last three GC intervals.
+: The minimum percentage of time spent in local garbage collection pauses. For the `gencon` policy, this refers to the amount of time spent on the nursery area of the heap (scavenge operation). For the `balanced` policy, this refers to the amount of time spent on the eden regions of the heap (PGC operation). 
 
-: This option applies only to the `gencon` GC policy.
+: This option applies only to the `gencon` and `balanced` GC policies.
 
 ### `dynamicBreadthFirstScanOrdering`
 

--- a/docs/xgc.md
+++ b/docs/xgc.md
@@ -140,7 +140,7 @@ Options that change the behavior of the garbage collector.
   |---------------|----------------|------------------------------|
   | `<value>`     | [percentage]   | 1 for gencon, 2 for balanced |
 
-: The minimum percentage of time spent in local garbage collection pauses. For the `gencon` policy, this refers to the amount of time spent on the nursery area of the heap (scavenge operation). For the `balanced` policy, this refers to the amount of time spent on the eden regions of the heap (PGC operation). 
+: The minimum percentage of time spent in local garbage collection pauses. For the `gencon` policy, this refers to the amount of time spent in Scavenge operation (on the nursery area of the heap). For the `balanced` policy, this refers to the amount of time spent in PGC operations (mostly on the eden and young regions, but also some other regions for de-fragmentation purposes). 
 
 : This option applies only to the `gencon` and `balanced` GC policies.
 

--- a/docs/xmn.md
+++ b/docs/xmn.md
@@ -25,27 +25,34 @@
 # -Xmn / -Xmns / -Xmnx
 
 
-Sets the initial and maximum size of the nursery area when using the [`gencon` garbage collection (GC) policy](gc.md#gencon-policy-default) (`-Xgcpolicy:gencon`). These options are ignored if they are used with any other GC policy.
+Sets the initial and maximum size of the nursery area when using the [`gencon` garbage collection (GC) policy](gc.md#gencon-policy-default) (`-Xgcpolicy:gencon`), and sets the size of eden when using the [`balanced` garbage collection (GC) policy](gc.md#balanced-policy) (`-Xgcpolicy:balanced`). These options are ignored if they are used with any other GC policy.
 
 You can use the `-verbose:sizes` option to find out the value that is being used by the VM.
 
 ## Syntax
 
-| Setting       | Effect                                         | Default                 |
-|---------------|------------------------------------------------|-------------------------|
-| `-Xmn<size>`  | Equivalent to setting both `-Xmns` and `-Xmnx` | Not set                 |
-| `-Xmns<size>` | Set initial size                               | 25% of [`-Xms`](xms.md) |
-| `-Xmnx<size>` | Set maximum size                               | 25% of [`-Xmx`](xms.md) |
+| Setting       | Effect                                         | Default                                                                                       |
+|---------------|------------------------------------------------|-----------------------------------------------------------------------------------------------|
+| `-Xmn<size>`  | Equivalent to setting both `-Xmns` and `-Xmnx` | Not set                                                                                       |
+| `-Xmns<size>` | Set initial size                               | 25% of [`-Xms`](xms.md) when using `gencon` and `balanced` policies                           |
+| `-Xmnx<size>` | Set maximum size                               | 25% of [`-Xmx`](xms.md) when using `gencon`, and 75% of [`-Xmx`](xms.md) when using `balanced`|
 
 See [Using -X command-line options](x_jvm_commands.md) for more information about the `<size>` parameter.
 
 :fontawesome-solid-exclamation-triangle:{: .warn aria-hidden="true"} **Restriction:** If you try to set `-Xmn` with either `-Xmns` or `-Xmnx`, the VM does not start, returning an error.
 
-To set the size of the tenure area of the heap, see [`-Xmo/-Xmos/-Xmox`](xmo.md).
+:fontawesome-solid-pencil-alt:{: .note aria-hidden="true"} **Notes:**
+
+- When using the `balanced` GC policy without specifying `-Xmn` or `-Xmns`, the GC may decide to shrink eden size below its initial size (25% of `-Xms`) if it determines that doing so will improve GC performance.
+- When using the `balanced` GC policy, specifying `-Xmn`/`-Xmns`/`-Xmnx` may affect `balanced` GC's ability to satisfy [`-Xgc:targetPausetime`](xgc.md#targetpausetime)
+- Specifying `-Xmn`/`-Xmns`/`-Xmnx` may affect both `gencon` and `balanced` GC's ability to satisfy [`-Xgc:dnssexpectedtimeratiomaximum`](xgc.md##dnssexpectedtimeratiomaximum) and [`-Xgc:dnssexpectedtimeratiominimum`](xgc.md##dnssexpectedtimeratiominimum)
+
+To set the size of the tenure area of the heap when using `gencon` GC policy, see [`-Xmo/-Xmos/-Xmox`](xmo.md).
 
 ## See also
 
-- [`gencon` policy (default)](gc.md#gencon-policy-default)
+- [`gencon` GC policy (default)](gc.md#gencon-policy-default)
+- [`balanced` GC policy](gc.md#balanced-policy)
 - [`-Xmo/-Xmos/-Xmox`](xmo.md)
 - [`-Xms`/`-Xmx`](xms.md)
 

--- a/docs/xmn.md
+++ b/docs/xmn.md
@@ -45,7 +45,7 @@ See [Using -X command-line options](x_jvm_commands.md) for more information abou
 
 - When using the `balanced` GC policy without specifying `-Xmn` or `-Xmns`, the GC may decide to shrink eden size below its initial size (25% of `-Xms`) if it determines that doing so will improve GC performance.
 - When using the `balanced` GC policy, specifying `-Xmn`/`-Xmns`/`-Xmnx` may affect `balanced` GC's ability to satisfy [`-Xgc:targetPausetime`](xgc.md#targetpausetime)
-- Specifying `-Xmn`/`-Xmns`/`-Xmnx` may affect both `gencon` and `balanced` GC's ability to satisfy [`-Xgc:dnssexpectedtimeratiomaximum`](xgc.md##dnssexpectedtimeratiomaximum) and [`-Xgc:dnssexpectedtimeratiominimum`](xgc.md##dnssexpectedtimeratiominimum)
+- Specifying `-Xmn`/`-Xmns`/`-Xmnx` may affect both `gencon` and `balanced` GC's ability to satisfy [`-Xgc:dnssexpectedtimeratiomaximum`](xgc.md#dnssexpectedtimeratiomaximum) and [`-Xgc:dnssexpectedtimeratiominimum`](xgc.md#dnssexpectedtimeratiominimum)
 
 To set the size of the tenure area of the heap when using `gencon` GC policy, see [`-Xmo/-Xmos/-Xmox`](xmo.md).
 

--- a/docs/xtgc.md
+++ b/docs/xtgc.md
@@ -59,6 +59,12 @@ Provides garbage collection tracing options.
 
 : Prints a line of output for every free chunk of memory in the system, including "dark matter" (free chunks that are not on the free list for some reason, typically because they are too small). Each line contains the base address and the size in bytes of the chunk. If the chunk is followed in the heap by an object, the size and class name of the object is also printed. This argument has a similar effect to the `terse` argument.
 
+### `file`
+
+        -Xtgc:file=<filename>
+
+: Directs the logs to a file. Otherwise they are directed to stderr.
+
 ### `freeList`
 
         -Xtgc:freeList
@@ -69,7 +75,13 @@ Provides garbage collection tracing options.
 
         -Xtgc:parallel
 
-: Produces statistics on the activity of the parallel threads during the mark and sweep phases of a global garbage collection.
+: Produces statistics on the activity of the parallel threads during each operation (mark, sweep, scavenge etc.) of a GC cycle.
+
+### `rootscantime`
+
+        -Xtgc:rootscantime
+
+: Prints duration of strong and weak roots scanning of a GC cycle.
 
 ### `scavenger`
 


### PR DESCRIPTION
Cherry pick the commits from https://github.com/eclipse-openj9/openj9-docs/pull/838 https://github.com/eclipse-openj9/openj9-docs/pull/839 https://github.com/eclipse-openj9/openj9-docs/pull/841 https://github.com/eclipse-openj9/openj9-docs/pull/891 https://github.com/eclipse-openj9/openj9-docs/pull/892 for the 0.30 branch.