### PR TITLE
(0.30.1) Create release notes for 0.30.1

### DIFF
--- a/docs/version0.30.1.md
+++ b/docs/version0.30.1.md
@@ -1,0 +1,48 @@
+<!--
+* Copyright (c) 2017, 2022 IBM Corp. and others
+*
+* This program and the accompanying materials are made
+* available under the terms of the Eclipse Public License 2.0
+* which accompanies this distribution and is available at
+* https://www.eclipse.org/legal/epl-2.0/ or the Apache
+* License, Version 2.0 which accompanies this distribution and
+* is available at https://www.apache.org/licenses/LICENSE-2.0.
+*
+* This Source Code may also be made available under the
+* following Secondary Licenses when the conditions for such
+* availability set forth in the Eclipse Public License, v. 2.0
+* are satisfied: GNU General Public License, version 2 with
+* the GNU Classpath Exception [1] and GNU General Public
+* License, version 2 with the OpenJDK Assembly Exception [2].
+*
+* [1] https://www.gnu.org/software/classpath/license.html
+* [2] http://openjdk.java.net/legal/assembly-exception.html
+*
+* SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH
+* Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+-->
+
+# What's new in version 0.30.1
+
+The following new features and notable changes since version 0.30.0 are included in this release:
+
+- [New binaries and changes to supported environments](#binaries-and-supported-environments)
+- [Creation of system dumps on macOS 12](#creation-of-system-dumps-on-macos-12)
+
+## Features and changes
+
+### Binaries and supported environments
+
+OpenJ9 release 0.30.1 supports OpenJDK 8, 11 and 17.
+
+To learn more about support for OpenJ9 releases, including OpenJDK levels and platform support, see [Supported environments](openj9_support.md).
+
+### Creation of system dumps on macOS 12
+
+Creation of system (core) dumps on macOS 12 or later is now possible.
+
+## Known problems and full release information
+
+To see known problems and a complete list of changes between Eclipse OpenJ9 v0.30.0 and v0.30.1 releases, see the [Release notes](https://github.com/eclipse-openj9/openj9/blob/master/doc/release-notes/0.30/0.30.1.md).
+
+<!-- ==== END OF TOPIC ==== version0.30.1.md ==== -->

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -102,11 +102,12 @@ nav:
 
     - "Release notes" :
         - "Overview"                                                             : openj9_releases.md
+        - "Version 0.30.1"                                                       : version0.30.1.md
         - "Version 0.30.0"                                                       : version0.30.md
         - "Version 0.29.1"                                                       : version0.29.1.md
         - "Version 0.29.0"                                                       : version0.29.md
-        - "Version 0.27.1"                                                       : version0.27.md
         - "Earlier releases" :
+            - "Version 0.27.1"                                                   : version0.27.md
             - "Version 0.26.0"                                                   : version0.26.md
             - "Version 0.25.0"                                                   : version0.25.md
             - "Version 0.24.0"                                                   : version0.24.md


### PR DESCRIPTION
Port of the parts of https://github.com/eclipse-openj9/openj9-docs/pull/895 needed to update the 0.30.1 branch.