### PR TITLE
https://github.com/eclipse-openj9/openj9-docs/issues/863

### DIFF
--- a/docs/tool_jcmd.md
+++ b/docs/tool_jcmd.md
@@ -62,7 +62,7 @@ The tool uses the Attach API, and has the following limitations:
 - Displays information for OpenJ9 Java processes only
 - Does not show information for processes whose Attach API is disabled. :fontawesome-solid-pencil-alt:{: .note aria-hidden="true"} **Note:** The Attach API is disabled by default on z/OS.
 
-For more information about the Attach API, including how to enable and secure it, see [Support for the Java Attach API](https://www.ibm.com/support/knowledgecenter/SSYKE2_8.0.0/com.ibm.java.vm.80.doc/docs/attachapi.html).
+For more information about the Attach API, including how to enable and secure it, see [Java Attach API](attachapi.md).
 
 
 <!-- ==== END OF TOPIC ==== tool_jcmd.md ==== -->

--- a/docs/tool_jmap.md
+++ b/docs/tool_jmap.md
@@ -69,4 +69,12 @@ The following tool limitations apply:
 - Displaying data from core dumps is not supported; use `jdmpview` instead.
 - Other options , such as `-F` (force a dump of an unresponsive process) can be accomplished using `kill -QUIT <pid>`.
 
+The tool uses the Attach API, and has the following limitations:
+
+- Displays information only for local processes that are owned by the current user, due to security considerations.
+- Displays information for OpenJ9 Java processes only
+- Does not show information for processes whose Attach API is disabled. :fontawesome-solid-pencil-alt:{: .note aria-hidden="true"} **Note:** The Attach API is disabled by default on z/OS.
+
+For more information about the Attach API, including how to enable and secure it, see [Support for the Java Attach API](https://www.ibm.com/support/knowledgecenter/SSYKE2_8.0.0/com.ibm.java.vm.80.doc/docs/attachapi.html).
+
 <!-- ==== END OF TOPIC ==== tool_jmap.md ==== -->

--- a/docs/tool_jmap.md
+++ b/docs/tool_jmap.md
@@ -71,10 +71,9 @@ The following tool limitations apply:
 
 The tool uses the Attach API, and has the following limitations:
 
-- Displays information only for local processes that are owned by the current user, due to security considerations.
 - Displays information for OpenJ9 Java processes only
 - Does not show information for processes whose Attach API is disabled. :fontawesome-solid-pencil-alt:{: .note aria-hidden="true"} **Note:** The Attach API is disabled by default on z/OS.
 
-For more information about the Attach API, including how to enable and secure it, see [Support for the Java Attach API](https://www.ibm.com/support/knowledgecenter/SSYKE2_8.0.0/com.ibm.java.vm.80.doc/docs/attachapi.html).
+For more information about the Attach API, including how to enable and secure it, see [Java Attach API](attachapi.md).
 
 <!-- ==== END OF TOPIC ==== tool_jmap.md ==== -->

--- a/docs/tool_jps.md
+++ b/docs/tool_jps.md
@@ -62,7 +62,7 @@ The tool uses the Attach API, and has the following limitations:
 - Does not list non-OpenJ9 Java processes
 - Does not list processes whose attach API is disabled. :fontawesome-solid-pencil-alt:{: .note aria-hidden="true"} **Note:** The Attach API is disabled by default on z/OS.
 
-For more information about the Attach API, including how to enable and secure it, see [Support for the Java Attach API](https://www.ibm.com/support/knowledgecenter/SSYKE2_8.0.0/com.ibm.java.vm.80.doc/docs/attachapi.html).
+For more information about the Attach API, including how to enable and secure it, see [Java Attach API](attachapi.md).
 
 
 <!-- ==== END OF TOPIC ==== tool_jps.md ==== -->

--- a/docs/tool_jstack.md
+++ b/docs/tool_jstack.md
@@ -51,6 +51,6 @@ The tool uses the Attach API, and has the following limitations:
 - Displays information for OpenJ9 Java processes only
 - Does not show information for processes whose Attach API is disabled. :fontawesome-solid-pencil-alt:{: .note aria-hidden="true"} **Note:** The Attach API is disabled by default on z/OS.
 
-For more information about the Attach API, including how to enable and secure it, see [Support for the Java Attach API](https://www.ibm.com/support/knowledgecenter/SSYKE2_8.0.0/com.ibm.java.vm.80.doc/docs/attachapi.html).
+For more information about the Attach API, including how to enable and secure it, see [Java Attach API](attachapi.md).
 
 <!-- ==== END OF TOPIC ==== tool_jstack.md ==== -->

--- a/docs/tool_jstack.md
+++ b/docs/tool_jstack.md
@@ -45,4 +45,12 @@ The values for `<options>*` are as follows:
 - This tool is not supported and is subject to change or removal in future releases.
 - Although similar in usage and output to the HotSpot tool of the same name, this tool is a different implementation that is specific to OpenJ9. For more information about differences, see [Switching to OpenJ9](tool_migration.md).
 
+The tool uses the Attach API, and has the following limitations:
+
+- Displays information only for local processes that are owned by the current user, due to security considerations.
+- Displays information for OpenJ9 Java processes only
+- Does not show information for processes whose Attach API is disabled. :fontawesome-solid-pencil-alt:{: .note aria-hidden="true"} **Note:** The Attach API is disabled by default on z/OS.
+
+For more information about the Attach API, including how to enable and secure it, see [Support for the Java Attach API](https://www.ibm.com/support/knowledgecenter/SSYKE2_8.0.0/com.ibm.java.vm.80.doc/docs/attachapi.html).
+
 <!-- ==== END OF TOPIC ==== tool_jstack.md ==== -->

--- a/docs/tool_jstat.md
+++ b/docs/tool_jstat.md
@@ -55,5 +55,13 @@ Class Loaded    Class Unloaded
 - This tool is not supported and is subject to change or removal in future releases.
 - Although similar in usage and output to the HotSpot tool of the same name, this tool is a different implementation that is specific to OpenJ9. For more information about differences, see [Switching to OpenJ9](tool_migration.md).
 
+The tool uses the Attach API, and has the following limitations:
+
+- Displays information only for local processes that are owned by the current user, due to security considerations.
+- Displays information for OpenJ9 Java processes only
+- Does not show information for processes whose Attach API is disabled. :fontawesome-solid-pencil-alt:{: .note aria-hidden="true"} **Note:** The Attach API is disabled by default on z/OS.
+
+For more information about the Attach API, including how to enable and secure it, see [Support for the Java Attach API](https://www.ibm.com/support/knowledgecenter/SSYKE2_8.0.0/com.ibm.java.vm.80.doc/docs/attachapi.html).
+
 <!-- ==== END OF TOPIC ==== tool_jstat.md ==== -->
 

--- a/docs/tool_jstat.md
+++ b/docs/tool_jstat.md
@@ -61,7 +61,7 @@ The tool uses the Attach API, and has the following limitations:
 - Displays information for OpenJ9 Java processes only
 - Does not show information for processes whose Attach API is disabled. :fontawesome-solid-pencil-alt:{: .note aria-hidden="true"} **Note:** The Attach API is disabled by default on z/OS.
 
-For more information about the Attach API, including how to enable and secure it, see [Support for the Java Attach API](https://www.ibm.com/support/knowledgecenter/SSYKE2_8.0.0/com.ibm.java.vm.80.doc/docs/attachapi.html).
+For more information about the Attach API, including how to enable and secure it, see [Java Attach API](attachapi.md).
 
 <!-- ==== END OF TOPIC ==== tool_jstat.md ==== -->
 


### PR DESCRIPTION
Added the Attach API related information to jmap, jstack, and jstat topics as it was missing.
Signed-off-by: Sreekala Gopakumar <sreekala.gopakumar@ibm.com>