### PR TITLE
https://github.com/eclipse-openj9/openj9-docs/issues/873

### DIFF
--- a/docs/tool_jmap.md
+++ b/docs/tool_jmap.md
@@ -69,4 +69,12 @@ The following tool limitations apply:
 - Displaying data from core dumps is not supported; use `jdmpview` instead.
 - Other options , such as `-F` (force a dump of an unresponsive process) can be accomplished using `kill -QUIT <pid>`.
 
+The tool uses the Attach API, and has the following limitations:
+
+- Displays information only for local processes that are owned by the current user, due to security considerations.
+- Displays information for OpenJ9 Java processes only
+- Does not show information for processes whose Attach API is disabled. :fontawesome-solid-pencil-alt:{: .note aria-hidden="true"} **Note:** The Attach API is disabled by default on z/OS.
+
+For more information about the Attach API, including how to enable and secure it, see [Support for the Java Attach API](https://www.ibm.com/support/knowledgecenter/SSYKE2_8.0.0/com.ibm.java.vm.80.doc/docs/attachapi.html).
+
 <!-- ==== END OF TOPIC ==== tool_jmap.md ==== -->

--- a/docs/tool_jstack.md
+++ b/docs/tool_jstack.md
@@ -45,4 +45,12 @@ The values for `<options>*` are as follows:
 - This tool is not supported and is subject to change or removal in future releases.
 - Although similar in usage and output to the HotSpot tool of the same name, this tool is a different implementation that is specific to OpenJ9. For more information about differences, see [Switching to OpenJ9](tool_migration.md).
 
+The tool uses the Attach API, and has the following limitations:
+
+- Displays information only for local processes that are owned by the current user, due to security considerations.
+- Displays information for OpenJ9 Java processes only
+- Does not show information for processes whose Attach API is disabled. :fontawesome-solid-pencil-alt:{: .note aria-hidden="true"} **Note:** The Attach API is disabled by default on z/OS.
+
+For more information about the Attach API, including how to enable and secure it, see [Support for the Java Attach API](https://www.ibm.com/support/knowledgecenter/SSYKE2_8.0.0/com.ibm.java.vm.80.doc/docs/attachapi.html).
+
 <!-- ==== END OF TOPIC ==== tool_jstack.md ==== -->

--- a/docs/tool_jstat.md
+++ b/docs/tool_jstat.md
@@ -55,5 +55,13 @@ Class Loaded    Class Unloaded
 - This tool is not supported and is subject to change or removal in future releases.
 - Although similar in usage and output to the HotSpot tool of the same name, this tool is a different implementation that is specific to OpenJ9. For more information about differences, see [Switching to OpenJ9](tool_migration.md).
 
+The tool uses the Attach API, and has the following limitations:
+
+- Displays information only for local processes that are owned by the current user, due to security considerations.
+- Displays information for OpenJ9 Java processes only
+- Does not show information for processes whose Attach API is disabled. :fontawesome-solid-pencil-alt:{: .note aria-hidden="true"} **Note:** The Attach API is disabled by default on z/OS.
+
+For more information about the Attach API, including how to enable and secure it, see [Support for the Java Attach API](https://www.ibm.com/support/knowledgecenter/SSYKE2_8.0.0/com.ibm.java.vm.80.doc/docs/attachapi.html).
+
 <!-- ==== END OF TOPIC ==== tool_jstat.md ==== -->
 

--- a/docs/xjit.md
+++ b/docs/xjit.md
@@ -55,6 +55,8 @@ These parameters can be used to modify the behavior of `-Xjit`:
 | [`verbose`       ](#verbose       ) | Reports information about the JIT and AOT compiler configuration and method compilation.|
 | [`vlog`          ](#vlog          ) | Sends verbose output to a file.                                                         |
 
+: :fontawesome-solid-pencil-alt:{: .note aria-hidden="true"} **Note:** The -Xjit option should only be specified once. If it's specified multiple times, only the last option takes effect. To specify multiple -Xjit parameters, use commas to separate the parameters; for example, -Xjit:enableGPU,exclude={ilog/rules/engine/sequential/generated/*}. Parameters such as exclude are additive and may be specified multiple times (but all within the same -Xjit option).
+
 ### `count`
 
         -Xjit:count=<n>


### PR DESCRIPTION
Added a note (after the Parameters table) that only the most recent -Xjit option takes effect.
Signed-off-by: Sreekala Gopakumar <sreekala.gopakumar@ibm.com>