### PR TITLE
Adjust -XX:MaxDirectMemorySize defaults

### DIFF
--- a/docs/version0.31.md
+++ b/docs/version0.31.md
@@ -29,6 +29,7 @@ The following new features and notable changes since version 0.30.0 are included
 - [New binaries and changes to supported environments](#binaries-and-supported-environments)
 - [Creation of system dumps on macOS 12](#creation-of-system-dumps-on-macos-12)
 - [New `-XX:[+|-]ShowHiddenFrames` option added](#new-xx-showhiddenframes-option-added)
+- ![Start of content that applies to Java 11 plus](cr/java11plus.png) [Modified default for `-XX:MaxDirectMemorySize`](#modified-default-for-xxmaxdirectmemorysize)
 - ![Start of content that applies to Java 18 plus](cr/java18plus.png) [New JDK 18 features](#new-jdk-18-features)
 
 ## Features and changes
@@ -45,7 +46,12 @@ Creation of system (core) dumps on macOS 12 or later is now possible.
 
 ### New `-XX:[+|-]ShowHiddenFrames` option added
 
-This option specifies if generated hidden MethodHandle frames are displayed in a stacktrace. See [-XX:[+|-]ShowHiddenFrames](xxshowhiddenframes.md) for more details.
+This option specifies if generated hidden MethodHandle frames are displayed in a stacktrace. See [`-XX:[+|-]ShowHiddenFrames`](xxshowhiddenframes.md) for more details.
+
+### ![Start of content that applies to Java 11 plus](cr/java11plus.png) Modified default for `-XX:MaxDirectMemorySize`
+
+[`-XX:MaxDirectMemorySize`](xxmaxdirectmemorysize.md) is no longer set by default and the class library limits the amount of heap memory used for
+Direct Byte Buffers to the same value as the maximum heap size.
 
 ### ![Start of content that applies to Java 18 plus](cr/java18plus.png) New JDK 18 features
 

--- a/docs/xxmaxdirectmemorysize.md
+++ b/docs/xxmaxdirectmemorysize.md
@@ -37,8 +37,9 @@ This Oracle HotSpot option sets a limit on the amount of memory that can be rese
 
 The value you choose is the limit on memory that can be reserved for all Direct Byte Buffers. If a value is set for this option, the sum of all Direct Byte Buffer sizes cannot exceed the limit. After the limit is reached, a new Direct Byte Buffer can be allocated only when enough old buffers are freed to provide enough space to allocate the new buffer.
 
-By default, the VM limits the amount of heap memory used for Direct Byte Buffers to approximately 85% of the maximum heap size.
+![Start of content that applies to Java 8](cr/java8.png) By default, the VM limits the amount of heap memory used for Direct Byte Buffers to approximately 87.5% of the maximum heap size.
 
+![Start of content that applies to Java 11 plus](cr/java11plus.png) By default, the class library limits the amount of heap memory used for Direct Byte Buffers to the same value as the maximum heap size.
 
 
 <!-- ==== END OF TOPIC ==== xxmaxdirectmemorysize.md ==== -->


### PR DESCRIPTION
Fixes https://github.com/eclipse-openj9/openj9-docs/issues/905