### PR TITLE
OpenJDK jdk11 is supported on OSX 10.11+

### DIFF
--- a/docs/openj9_support.md
+++ b/docs/openj9_support.md
@@ -135,7 +135,7 @@ OpenJDK 11 binaries are expected to function on the minimum operating system lev
 
 | macOS                                     | x64                                                                                  |
 |-------------------------------------------|--------------------------------------------------------------------------------------|
-| OS X 10.10.0+                             | :fontawesome-solid-check:{: .yes aria-hidden="true"}<span class="sr-only">yes</span> |
+| OS X 10.11+                               | :fontawesome-solid-check:{: .yes aria-hidden="true"}<span class="sr-only">yes</span> |
 
 | AIX                                       | ppc64                                                                                |
 |-------------------------------------------|--------------------------------------------------------------------------------------|


### PR DESCRIPTION
https://www.oracle.com/java/technologies/javase/products-doc-jdk11certconfig.html

See also https://github.com/eclipse-openj9/openj9-docs/pull/912