### PR TITLE
Update RAS documentation regarding Hidden frames

### DIFF
--- a/docs/cmdline_migration.md
+++ b/docs/cmdline_migration.md
@@ -65,6 +65,7 @@ You can use the following command-line options in OpenJ9, just as you did in Hot
 | [`-XX:ParallelCMSThreads`](xxparallelcmsthreads.md)              | Configures the number of GC mutator background threads.                                                                                      |
 | [`-XX:ParallelGCThreads`](xxparallelgcthreads.md)                | Configures the number of GC threads.                                                                                                         |
 | [`-XX:[+|-]PrintCodeCache`](xxprintcodecache.md)                 | Prints code cache usage when the application exits.                                                                                          |
+| [`-XX:[+|-]ShowHiddenFrames`](xxshowhiddenframes.md)             | Specifies whether generated hidden `MethodHandle` frames are displayed in a stack trace. :fontawesome-solid-pencil-alt:{: .note aria-hidden="true"} **Note:** Unlike HotSpot, this option doesn't require the `+UnlockDiagnosticVMOptions` option.                                                                                         |
 | [`-XX:[+|-]UseCompressedOops`](xxusecompressedoops.md)           | Disables compressed references in 64-bit JVMs. (See also [`-Xcompressedrefs`](xcompressedrefs.md))                                           |
 | [`-XX:[+|-]UseContainerSupport`](xxusecontainersupport.md)       | Sets a larger fraction of memory to the Java heap when the VM detects that it is running in a container.                                     |
 

--- a/docs/version0.32.md
+++ b/docs/version0.32.md
@@ -28,7 +28,7 @@ The following new features and notable changes since version 0.30.0 are included
 
 - [New binaries and changes to supported environments](#binaries-and-supported-environments)
 - [Creation of system dumps on macOS 12](#creation-of-system-dumps-on-macos-12)
-- [New `-XX:[+|-]ShowHiddenFrames` option added](#new-xx-showhiddenframes-option-added)
+- [Support for OpenJDK HotSpot options](#support-for-openjdk-hotspot-options)
 - [`SharedClassStatistics` API updated](#sharedclassstatistics-api-updated)
 - ![Start of content that applies to Java 11 plus](cr/java11plus.png) [Modified default value for `-XX:MaxDirectMemorySize`](#modified-default-value-for-xxmaxdirectmemorysize)
 - ![Start of content that applies to Java 18 plus](cr/java18plus.png) [New JDK 18 features](#new-jdk-18-features)
@@ -45,9 +45,12 @@ To learn more about support for OpenJ9 releases, including OpenJDK levels and pl
 
 You can now create system (core) dumps on macOS 12 or later.
 
-### New `-XX:[+|-]ShowHiddenFrames` option added
 
-This option specifies whether generated hidden MethodHandle frames are displayed in a stack trace. For more information, see [`-XX:[+|-]ShowHiddenFrames`](xxshowhiddenframes.md).
+### Support for OpenJDK HotSpot options
+
+For compatibility, the following OpenJDK HotSpot options are now supported by OpenJ9:
+
+- [`-XX:[+|-]ShowHiddenFrames`](xxshowhiddenframes.md). This option specifies whether generated hidden `MethodHandle` frames are displayed in a stack trace.
 
 ### `SharedClassStatistics` API updated
 

--- a/docs/xxshowhiddenframes.md
+++ b/docs/xxshowhiddenframes.md
@@ -39,7 +39,7 @@ Unlike the HotSpot implementation, this option doesn't require the `+UnlockDiagn
 | `-XX:+ShowHiddenFrames`  | Enable  |                                                                                      |
 | `-XX:-ShowHiddenFrames`  | Disable | :fontawesome-solid-check:{: .yes aria-hidden="true"}<span class="sr-only">yes</span> |
 
-:   When disabled, this option causes the VM to hide generated hidden MethodHandle frames in a stacktrace.  
+:   When disabled, this option causes the VM to hide generated hidden `MethodHandle` frames in a stacktrace.  
 
 
 <!-- ==== END OF TOPIC ==== xxshowhiddenframes.md ==== -->

--- a/docs/xxshowhiddenframes.md
+++ b/docs/xxshowhiddenframes.md
@@ -24,7 +24,11 @@
 
 # -XX:\[+|-\]ShowHiddenFrames
 
-This option enables or disables the display of generated hidden MethodHandle frames in a stacktrace.
+This reimplementation of the Oracle HotSpot diagonostic option enables or disables the display of generated hidden `MethodHandle` frames in a stack trace.
+
+This option doesn't affect the contents of dump files.
+
+Unlike the HotSpot implementation, this option doesn't require the `+UnlockDiagnosticVMOptions` option.
 
 ## Syntax
 
@@ -35,8 +39,7 @@ This option enables or disables the display of generated hidden MethodHandle fra
 | `-XX:+ShowHiddenFrames`  | Enable  |                                                                                      |
 | `-XX:-ShowHiddenFrames`  | Disable | :fontawesome-solid-check:{: .yes aria-hidden="true"}<span class="sr-only">yes</span> |
 
-:   The option, `-XX:-ShowHiddenFrames`, causes the VM to hide generated hidden MethodHandle frames in a stacktrace. This is the default option.
+:   When disabled, this option causes the VM to hide generated hidden MethodHandle frames in a stacktrace.  
 
-    When specifying the `-XX:+ShowHiddenFrames` option, the VM displays these generated hidden MethodHandle frames in a stacktrace.
 
 <!-- ==== END OF TOPIC ==== xxshowhiddenframes.md ==== -->


### PR DESCRIPTION
https://github.com/eclipse-openj9/openj9-docs/issues/910

Updated the ShowHiddenFrames content to mention HotSpot for consistency. Added that this option doesn't affect the dump file. Added this option to the table in the Switching to OpenJ9 topic.

Signed-off-by: Sreekala Gopakumar <sreekala.gopakumar@ibm.com>