### PR TITLE
AIX 11.0.16 requires the 16.1 XL C++ Runtime

### DIFF
--- a/docs/configuring.md
+++ b/docs/configuring.md
@@ -35,7 +35,7 @@ On some systems, a further environment variable might be required if your applic
 - **DYLD_LIBRARY_PATH** (macOS&reg;)
 - **PATH** (Windows&reg;)
 
-![Start of content that applies to Java 14+](cr/java14plus.png) Although most Java applications should run without changing anything on the underlying system, a unique pre-requisite exists for AIX systems on OpenJDK version 14 and later; you must have the [XL C++ Runtime](https://www.ibm.com/support/pages/xl-cc-runtime-aix-v16101-fix-pack-december-2018) installed. ![End of content that applies only to Java 14 and later](cr/java_close.png)
+![Start of content that applies to Java 11+](cr/java11plus.png) Although most Java applications should run without changing anything on the underlying system, a unique pre-requisite exists for AIX systems on OpenJDK version 11 and later; you must have the [16.1 XL C++ Runtime](https://www.ibm.com/support/pages/fix-list-xl-cc-runtime-aix#161X) installed. ![End of content that applies only to Java 11 and later](cr/java_close.png)
 
 ## Setting resource limits (AIX, Linux, and macOS)
 

--- a/docs/openj9_support.md
+++ b/docs/openj9_support.md
@@ -141,6 +141,8 @@ OpenJDK 11 binaries are expected to function on the minimum operating system lev
 | AIX 7.1 TL5                               | :fontawesome-solid-check:{: .yes aria-hidden="true"}<span class="sr-only">yes</span> |
 | AIX 7.2 TL4                               | :fontawesome-solid-check:{: .yes aria-hidden="true"}<span class="sr-only">yes</span> |
 
+:fontawesome-solid-bell:{: .warn aria-hidden="true"} **Important:** AIX OpenJ9 builds require the [16.1 XL C++ Runtime](https://www.ibm.com/support/pages/fix-list-xl-cc-runtime-aix#161X).
+
 When public support for an operating system version ends, OpenJ9 can no longer be supported on that level.
 
 
@@ -251,7 +253,7 @@ The project builds and tests OpenJDK with OpenJ9 on a number of platforms. The o
 | Linux AArch64 64-bit          | CentOS 7.9             | gcc 7.5                               |
 | Windows x86 64-bit            | Windows Server 2012 R2 | Microsoft Visual Studio 2017          |
 | macOS x86 64-bit              | macOS 10.14.6          | xcode 10.3 and clang 10.0.1           |
-| AIX POWER BE 64-bit           | AIX 7.1 TL05           | xlc/C++ 13.1.3                        |
+| AIX POWER BE 64-bit           | AIX 7.1 TL05           | xlc/C++ 16.1.0                        |
 
 ### OpenJDK 17
 

--- a/docs/version0.33.md
+++ b/docs/version0.33.md
@@ -1,0 +1,49 @@
+<!--
+* Copyright (c) 2017, 2022 IBM Corp. and others
+*
+* This program and the accompanying materials are made
+* available under the terms of the Eclipse Public License 2.0
+* which accompanies this distribution and is available at
+* https://www.eclipse.org/legal/epl-2.0/ or the Apache
+* License, Version 2.0 which accompanies this distribution and
+* is available at https://www.apache.org/licenses/LICENSE-2.0.
+*
+* This Source Code may also be made available under the
+* following Secondary Licenses when the conditions for such
+* availability set forth in the Eclipse Public License, v. 2.0
+* are satisfied: GNU General Public License, version 2 with
+* the GNU Classpath Exception [1] and GNU General Public
+* License, version 2 with the OpenJDK Assembly Exception [2].
+*
+* [1] https://www.gnu.org/software/classpath/license.html
+* [2] http://openjdk.java.net/legal/assembly-exception.html
+*
+* SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH
+* Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+-->
+
+# What's new in version 0.33.0
+
+The following new features and notable changes since version 0.30.0 are included in this release:
+
+- [New binaries and changes to supported environments](#binaries-and-supported-environments)
+- ![Start of content that applies to Java 11](cr/java11.png) [XL C++ Runtime required on AIX](#xl-c-runtime-required-on-aix)
+
+## Features and changes
+
+### Binaries and supported environments
+
+OpenJ9 release 0.33.0 supports OpenJDK 8, 11, 17, and 18.
+
+To learn more about support for OpenJ9 releases, including OpenJDK levels and platform support, see [Supported environments](openj9_support.md).
+
+### ![Start of content that applies to Java 11](cr/java11.png) XL C++ Runtime required on AIX
+
+AIX OpenJ9 builds now require version 16.1 of the [IBM XL C++ Runtime](https://www.ibm.com/support/pages/fix-list-xl-cc-runtime-aix#161X).
+This was already required for OpenJDK 17 and is now also required from 11.0.16 to accommodate a security update to the HarfBuzz text shaping library.
+
+## Known problems and full release information
+
+To see known problems and a complete list of changes between Eclipse OpenJ9 v0.32.0 and v0.33.0 releases, see the [Release notes](https://github.com/eclipse-openj9/openj9/blob/master/doc/release-notes/0.33/0.33.md).
+
+<!-- ==== END OF TOPIC ==== version0.33.md ==== -->

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -102,12 +102,13 @@ nav:
 
     - "Release notes" :
         - "Overview"                                                             : openj9_releases.md
+        - "Version 0.33.0"                                                       : version0.33.md
         - "Version 0.32.0"                                                       : version0.32.md
         - "Version 0.30.1"                                                       : version0.30.1.md
         - "Version 0.30.0"                                                       : version0.30.md
-        - "Version 0.29.1"                                                       : version0.29.1.md
-        - "Version 0.29.0"                                                       : version0.29.md
         - "Earlier releases" :
+            - "Version 0.29.1"                                                   : version0.29.1.md
+            - "Version 0.29.0"                                                   : version0.29.md
             - "Version 0.27.1"                                                   : version0.27.md
             - "Version 0.26.0"                                                   : version0.26.md
             - "Version 0.25.0"                                                   : version0.25.md


### PR DESCRIPTION
Fixes https://github.com/eclipse-openj9/openj9-docs/issues/932