### PR TITLE
jdk17+ Linux platforms use gcc 10.3 to compile

### DIFF
--- a/docs/openj9_support.md
+++ b/docs/openj9_support.md
@@ -259,10 +259,10 @@ The project builds and tests OpenJDK with OpenJ9 on a number of platforms. The o
 
 | Platform                      | Operating system       | Compiler                              |
 |-------------------------------|------------------------|---------------------------------------|
-| Linux x86 64-bit              | CentOS 7.9             | gcc 7.5                               |
-| Linux on POWER LE 64-bit      | CentOS 7.9             | gcc 7.5                               |
-| Linux on IBM Z 64-bit         | RHEL 7.9               | gcc 7.5                               |
-| Linux AArch64 64-bit          | CentOS 7.9             | gcc 7.5                               |
+| Linux x86 64-bit              | CentOS 7.9             | gcc 10.3                               |
+| Linux on POWER LE 64-bit      | CentOS 7.9             | gcc 10.3                               |
+| Linux on IBM Z 64-bit         | RHEL 7.9               | gcc 10.3                               |
+| Linux AArch64 64-bit          | CentOS 7.9             | gcc 10.3                               |
 | Windows x86 64-bit            | Windows Server 2012 R2 | Microsoft Visual Studio 2019          |
 | macOS x86 64-bit              | macOS 10.14.6          | xcode 10.3 and clang 10.0.1           |
 | AIX POWER BE 64-bit           | AIX 7.1 TL05           | xlc/C++ 16.1.0                        |
@@ -271,10 +271,10 @@ The project builds and tests OpenJDK with OpenJ9 on a number of platforms. The o
 
 | Platform                      | Operating system       | Compiler                              |
 |-------------------------------|------------------------|---------------------------------------|
-| Linux x86 64-bit              | CentOS 7.9             | gcc 7.5                               |
-| Linux on POWER LE 64-bit      | CentOS 7.9             | gcc 7.5                               |
-| Linux on IBM Z 64-bit         | RHEL 7.9               | gcc 7.5                               |
-| Linux AArch64 64-bit          | CentOS 7.9             | gcc 7.5                               |
+| Linux x86 64-bit              | CentOS 7.9             | gcc 10.3                               |
+| Linux on POWER LE 64-bit      | CentOS 7.9             | gcc 10.3                               |
+| Linux on IBM Z 64-bit         | RHEL 7.9               | gcc 10.3                               |
+| Linux AArch64 64-bit          | CentOS 7.9             | gcc 10.3                               |
 | Windows x86 64-bit            | Windows Server 2012 R2 | Microsoft Visual Studio 2019          |
 | macOS x86 64-bit              | macOS 10.14.6          | xcode 10.3 and clang 10.0.1           |
 | AIX POWER BE 64-bit           | AIX 7.1 TL05           | xlc/C++ 16.1.0                        |

--- a/docs/version0.33.md
+++ b/docs/version0.33.md
@@ -28,6 +28,7 @@ The following new features and notable changes since version 0.30.0 are included
 
 - [New binaries and changes to supported environments](#binaries-and-supported-environments)
 - ![Start of content that applies to Java 11](cr/java11.png) [XL C++ Runtime required on AIX](#xl-c-runtime-required-on-aix)
+- ![Start of content that applies to Java 17 plus](cr/java17plus.png) [Linux reference compiler updated to gcc 10.3](#linux-reference-compiler-updated-to-gcc-103)
 
 ## Features and changes
 
@@ -41,6 +42,11 @@ To learn more about support for OpenJ9 releases, including OpenJDK levels and pl
 
 AIX OpenJ9 builds now require version 16.1 of the [IBM XL C++ Runtime](https://www.ibm.com/support/pages/fix-list-xl-cc-runtime-aix#161X).
 This was already required for OpenJDK 17 and is now also required from 11.0.16 to accommodate a security update to the HarfBuzz text shaping library.
+
+### ![Start of content that applies to Java 17 plus](cr/java17plus.png) Linux reference compiler updated to gcc 10.3
+
+Linux builds for all platforms now use gcc 10.3 instead of gcc 7.5. See the list of [build environments](openj9_support.md#build-environments).
+
 
 ## Known problems and full release information
 


### PR DESCRIPTION
Closes https://github.com/eclipse-openj9/openj9-docs/issues/938