### PR TITLE
Modified -Xmint/-Xmaxt and -Xminf/-Xmaxf for balanced GC

### DIFF
--- a/docs/version0.30.md
+++ b/docs/version0.30.md
@@ -30,7 +30,7 @@ The following new features and notable changes since version 0.29.0 are included
 - [Changes to the shared classes cache generation number](#changes-to-the-shared-classes-cache-generation-number)
 - [Ignored options now captured in java dumps](#ignored-options-captured-in-java-dumps)
 - [New `-XX:[+|-]EnsureHashed` option added](#new-xx-ensurehashed-option-added)
-- [Redesigned heap resizing for the the `balanced` GC policy](#redesigned-heap-resizing-for-the-balanced-gc-policy)
+- [Redesigned heap resizing for the `balanced` GC policy](#redesigned-heap-resizing-for-the-balanced-gc-policy)
 
 ## Features and changes
 
@@ -65,7 +65,7 @@ This option specifies/unspecifies classes of objects that will be hashed and ext
 
 Heap resizing heuristics have been redesigned for the `balanced` GC policy. This includes both total heap resizing including eden and non-eden components independently, and also balancing between these two components when the heap is fully expanded. The heuristics now combine both the CPU overhead (for Partial GCs as well as Global Mark Phase) and the heap occupancy criteria. The balancing between eden and non-eden for fully expanded heaps is far more dynamic (instead of being mostly fixed in the ratio 1:4).
 
-As a consequence, there should typically be less need for heap sizing tuning options, most notably for eden sizing options [-Xmn, -Xmns, and -Xmnx](xmn.md). 
+As a consequence, there should typically be less need for heap sizing tuning options, most notably for eden sizing options [-Xmn, -Xmns, and -Xmnx](xmn.md).
 
 Also, a new soft limit pause target is added for Partial GCs, which defaults to 200ms. This criterion is combined with the PGC CPU overhead criterion for a balanced compromise between minimizing footprint, maximizing throughput, and meeting the paused time target.
 
@@ -75,7 +75,7 @@ More details about the new heuristics can be found at:
 
 The heuristics now obey the following existing options that were previously used for the `optthruput`, `optavgpause`, and `gencon` GC policies:
 
-- [-Xmint/-Xmaxt](xmint.md)  
+- [-Xmint/-Xmaxt](xmint.md)
 - [-Xgc:dnssExpectedTimeRatioMaximum/Minimum](xgc.md#dnssexpectedtimeratiomaximum)
 
 The heuristics also use the [-Xgc:targetPausetime](xgc.md#targetpausetime) option that was previously used only for the `metronome` GC policy.

--- a/docs/version0.30.md
+++ b/docs/version0.30.md
@@ -30,7 +30,7 @@ The following new features and notable changes since version 0.29.0 are included
 - [Changes to the shared classes cache generation number](#changes-to-the-shared-classes-cache-generation-number)
 - [Ignored options now captured in java dumps](#ignored-options-captured-in-java-dumps)
 - [New `-XX:[+|-]EnsureHashed` option added](#new-xx-ensurehashed-option-added)
-- [Redesigned heap resizing for balanced GC policy](#redesigned-heap-resizing-for-balanced-gc-policy)
+- [Redesigned heap resizing for the the `balanced` GC policy](#redesigned-heap-resizing-for-the-balanced-gc-policy)
 
 ## Features and changes
 
@@ -46,7 +46,7 @@ The format of classes that are stored in the shared classes cache is changed, wh
 
 ### Ignored options captured in java dumps
 
-For improved compatibility with other Java implementations, OpenJ9 ignores many command-line options. If any were ignored, they are now listed in java dump files. For example, this command
+For improved compatibility with other Java implementations, OpenJ9 ignores many command-line options. If any were ignored, they are now listed in the java dump files. For example, the command
 <pre>
 java -Xdump:java:events=vmstop -XX:+UseCompressedOop -XX:CompressedClassSpaceSize=528482304 -version
 </pre>
@@ -61,28 +61,26 @@ would yield the following in the <tt>ENVINFO</tt> section after the complete lis
 
 This option specifies/unspecifies classes of objects that will be hashed and extended with a hash slot upon object creation or first move. This option may improve performance for applications that frequently hash objects of a certain type. See [-XX:[+|-]EnsureHashed](xxensurehashed.md) for more details.
 
-### Redesigned heap resizing for balanced GC policy
+### Redesigned heap resizing for the `balanced` GC policy
 
-Heap resizing heuristics have been redesigned for balanced GC. This includes both total heap resizing including Eden and non-Eden components indenpendantly, and also balancing between these two components when heap is fully expanded. The heuristics now combine both CPU overhead (for both Partial GCs and Global Mark Phase) and heap occupancy criteria. The balancing between Eden and non-Eden for fully expanded heaps is far more dynamic (instead of being mostly fixed to ratio 1:4).
+Heap resizing heuristics have been redesigned for the `balanced` GC policy. This includes both total heap resizing including eden and non-eden components independently, and also balancing between these two components when the heap is fully expanded. The heuristics now combine both the CPU overhead (for Partial GCs as well as Global Mark Phase) and the heap occupancy criteria. The balancing between eden and non-eden for fully expanded heaps is far more dynamic (instead of being mostly fixed in the ratio 1:4).
 
-As a consequence there should typically be less need for heap sizing tuning options, most notably for Eden sizing options [-Xmn/mns/mnx](xmn.md). 
+As a consequence, there should typically be less need for heap sizing tuning options, most notably for eden sizing options [-Xmn, -Xmns, and -Xmnx](xmn.md). 
 
-Also, a new soft limit pause target is added for Partial GCs, that defaults to 200ms. This criteria is combined with PGC CPU overhead critera for a balanced compromise between minimizing footprint, maximizing throughput and meeting the paused time target.
+Also, a new soft limit pause target is added for Partial GCs, which defaults to 200ms. This criterion is combined with the PGC CPU overhead criterion for a balanced compromise between minimizing footprint, maximizing throughput, and meeting the paused time target.
 
-More details about the new heurstics can be found at:
+More details about the new heuristics can be found at:
 
 [https://blog.openj9.org/2021/09/24/balanced-gc-performance-improvements-eden-heap-sizing-improvements/](https://blog.openj9.org/2021/09/24/balanced-gc-performance-improvements-eden-heap-sizing-improvements/)
 
-The heuristcs now obey existing options
+The heuristics now obey the following existing options that were previously used for the `optthruput`, `optavgpause`, and `gencon` GC policies:
 
-[-Xmint/-Xmaxt](xmint.md) and <br /> 
-[-Xgc:dnssExpectedTimeRatioMaximum/Minimum](xgc.md#dnssexpectedtimeratiomaximum)
+- [-Xmint/-Xmaxt](xmint.md)  
+- [-Xgc:dnssExpectedTimeRatioMaximum/Minimum](xgc.md#dnssexpectedtimeratiomaximum)
 
-previously used for optthruput/optavgpause/gencon GC policies and also
+The heuristics also use the [-Xgc:targetPausetime](xgc.md#targetpausetime) option that was previously used only for the `metronome` GC policy.
 
-[-Xgc:targetPausetime](xgc.md#targetpausetime)
-
-previosly used only for Metronome GC policy.
+For more information about GC policies, see [Garbage collection policies](gc.md).
 
 
 ## Known problems and full release information

--- a/docs/xgcpolicy.md
+++ b/docs/xgcpolicy.md
@@ -61,7 +61,7 @@ For a detailed description of the policies, when to use them, and how they work,
 
 : The `balanced` policy also exploits large systems that have Non-Uniform Memory Architecture (NUMA) characteristics (x86 and POWER&trade; platforms only), which might further improve application throughput.
 
-: :fontawesome-solid-pencil-alt:{: .note aria-hidden="true"} **Note:** If you are using this GC policy in a Docker container that uses the default `seccomp` Docker profile, you must start the container with `--security-opt seccomp=unconfined` to exploit NUMA characteristics. These options are not required if you are running in Kubernetes, because `unconfined` is set by default (see [Seccomp]( https://kubernetes.io/docs/concepts/policy/pod-security-policy/#seccomp)).
+: :fontawesome-solid-pencil-alt:{: .note aria-hidden="true"} **Note:** If you are using this GC policy in a Docker container that uses the default `seccomp` Docker profile, you must start the container with `--security-opt seccomp=unconfined` to exploit NUMA characteristics. These options are not required if you are running in Kubernetes because `unconfined` is set by default (see [Seccomp]( https://kubernetes.io/docs/concepts/policy/pod-security-policy/#seccomp)).
 
 : To learn more about this policy, how it works, and when to use it, see [Garbage collection: `balanced` policy](gc.md#balanced-policy).
 
@@ -108,6 +108,9 @@ The behavior of the following options is different when specified with `-Xgcpoli
 
 [`-Xnocompactexplicitgc`](xcompactexplicitgc.md)
 : Disables compaction in explicit Global GC cycles. Compaction in implicit Global GC remains optional, triggered by internal heuristics.
+
+[`-Xgc:targetPausetime`](xgc.md#targetpausetime)
+: Uses the specified GC pause time as a soft GC pause time target.
 
 The following options are ignored when specified with `-Xgcpolicy:balanced`:
 
@@ -162,9 +165,10 @@ The following options are specific to the `metronome` GC policy:
 - [`-Xgc:nosynchronousGCOnOOM`](xgc.md#nosynchronousgconoom)
 - [`-Xgc:overrideHiresTimerCheck`](xgc.md#overridehirestimercheck)
 - [`-Xgc:synchronousGCOnOOM`](xgc.md#synchronousgconoom)
-- [`-Xgc:targetPausetime`](xgc.md#targetpausetime)
 - [`-Xgc:targetUtilization`](xgc.md#targetutilization)
 - [`-Xgc:verbosegcCycleTime`](xgc.md#verbosegccycletime)
+
+[`-Xgc:targetPausetime`](xgc.md#targetpausetime) option also applies to the `metronome` GC policy. This option applies only to the `metronome` and `balanced` GC policies.
 
 ### `nogc`
 

--- a/docs/xminf.md
+++ b/docs/xminf.md
@@ -38,14 +38,16 @@ If the free space is above or below these limits, the OpenJ9 VM attempts to adju
 
 The value range is 0.0 - 1.0.
 
+- For the `balanced` GC policy, these values apply only to the non-eden space part of the heap. The non-eden heap resizing decision is made by observing both `-Xmint`/`-Xmaxt` and `-Xminf`/`-Xmaxf`. Free memory in eden space is not considered for `-Xminf`/`-Xmaxf` purposes.
 - For the `gencon` GC policy, the values apply only to the tenure part of the heap and only at global GC points.
 - For the `optthruput` and `optavgpause` GC policies, these values apply to the whole heap at every GC point.
-
-This option cannot be used with the metronome GC policy (`-Xgcpolicy:metronome`) because the heap is always fully expanded.
+- This option cannot be used with the metronome GC policy (`-Xgcpolicy:metronome`) because the heap is always fully expanded.
 
 ## See also
 
 - [Heap expansion and contraction](allocation.md#expansion-and-contraction)
+- [Garbage collection policies](gc.md)
+
 
 
 <!-- ==== END OF TOPIC ==== xminf.md ==== -->

--- a/docs/xmint.md
+++ b/docs/xmint.md
@@ -25,7 +25,7 @@
 # -Xmint / -Xmaxt
 
 
-Sets the minimum and maximum proportion of time to spend in the garbage collection (GC) process as a percentage of the overall running time that included the last three GC runs.
+Sets the minimum and maximum proportion of time to spend in the garbage collection (GC) process as a percentage of the overall running time that included the last three GC runs. Therefore, the time spent in the GC process includes time spent in global mark phase and global GC operations but excludes partial garbage collection pauses because the latter apply only to the eden space.
 
 - If the percentage of time drops to less than the minimum, the OpenJ9 VM tries to shrink the heap.
 - If the percentage of time exceeds the maximum, the VM tries to expand the heap.
@@ -37,16 +37,21 @@ Sets the minimum and maximum proportion of time to spend in the garbage collecti
 
 ## Syntax
 
-| Setting        | Effect                 | Default |
-|----------------|------------------------|---------|
-|`-Xmint<value>` | Set minimum time in GC | 0.05       |
-|`-Xmaxt<value>` | Set maximum time in GC | 0.13      |
+| Setting        | Effect                 | Default for balanced policy|Default for other policies|
+|----------------|------------------------|:---------:|:-------------------------------:|
+|`-Xmint<value>` | Set minimum time in GC | 0.02    |0.05                          |
+|`-Xmaxt<value>` | Set maximum time in GC | 0.05   |0.13                           |
 
-For the `gencon` GC policy, the values apply only to the tenure part of the heap. For the `balanced`, `optthruput`, and `optavgpause` GC policies, these values apply to the whole heap. This option cannot be used with the metronome GC policy (`-Xgcpolicy:metronome`) because the heap is always fully expanded.
+- For the `balanced` GC policy, the values apply only to the non-eden space part of the heap. The non-eden heap resizing decision is made by observing both `-Xmint`/`-Xmaxt` and `-Xminf`/`-Xmaxf`.
+- For the `gencon` GC policy, the values apply only to the tenure part of the heap.
+- For the `optthruput`, and `optavgpause` GC policies, these values apply to the whole heap.
+- This option cannot be used with the `metronome` GC policy (`-Xgcpolicy:metronome`) because the heap is always fully expanded.
+
 
 ## See also
 
 - [Heap expansion and contraction](allocation.md#expansion-and-contraction)
+- [Garbage collection policies](gc.md)
 
 <!-- ==== END OF TOPIC ==== xmint.md ==== -->
 <!-- ==== END OF TOPIC ==== xmaxt.md ==== -->


### PR DESCRIPTION
https://github.com/eclipse-openj9/openj9-docs/issues/835

-Xmint/-Xmaxt, -Xminf/-Xmaxf, and -Xgcpolicy topics modified to reflect the changes applicable for the balanced GC policy.

Signed-off-by: Sreekala Gopakumar sreekala.gopakumar@ibm.com