### PR TITLE
Update to reflect JITServer support for openssl 3

### DIFF
--- a/docs/jitserver.md
+++ b/docs/jitserver.md
@@ -67,7 +67,7 @@ If a JITServer server crashes, the client is forced to perform compilations loca
 
 ## Security
 
-You can encrypt network communication between the client VM and JITServer by using OpenSSL 1.0.x or 1.1.x (JITServer technology currently does not support OpenSSL 3.0.x). To enable encryption, you specify the private key and the certificate at the server and use the certificate at the client. For more information, see [-XX:JITServerSSLCert / -XX:JITServerSSLKey / -XX:JITServerSSLRootCerts](xxjitserversslcert.md).
+You can encrypt network communication between the client VM and JITServer by using OpenSSL 1.0.x, 1.1.x, or 3.0.x. To enable encryption, you specify the private key and the certificate at the server and use the certificate at the client. For more information, see [-XX:JITServerSSLCert / -XX:JITServerSSLKey / -XX:JITServerSSLRootCerts](xxjitserversslcert.md).
 
 ## Tuning JITServer
 

--- a/docs/version0.33.md
+++ b/docs/version0.33.md
@@ -30,6 +30,7 @@ The following new features and notable changes since version 0.30.0 are included
 - ![Start of content that applies to Java 11](cr/java11.png) [XL C++ Runtime required on AIX](#xl-c-runtime-required-on-aix)
 - ![Start of content that applies to Java 17 plus](cr/java17plus.png) [Linux reference compiler updated to gcc 10.3](#linux-reference-compiler-updated-to-gcc-103)
 - [Control groups v2 support](#control-groups-v2-support)
+- [Support for OpenSSL 3.0.x](#support-for-openssl-30x)
 
 ## Features and changes
 
@@ -53,6 +54,10 @@ Linux builds for all platforms now use gcc 10.3 instead of gcc 7.5. See the list
 ### Control groups v2 support
 
 The Linux kernel has two variants of [control groups (cgroups): v1 and v2](https://man7.org/linux/man-pages/man7/cgroups.7.html). Many Linux operating systems are gradually transitioning from cgroups v1 to v2 as their default choice. Now, OpenJ9 has added cgroups v2 support which is identical to the support for cgroups v1.
+
+### Support for OpenSSL 3.0.x
+
+The JITServer technology feature now supports OpenSSL 3.0.x. For more information about OpenSSL support, see [`Cryptographic operations`](introduction.md#cryptographic-operations).
 
 ## Known problems and full release information
 

--- a/docs/xxjitserversslcert.md
+++ b/docs/xxjitserversslcert.md
@@ -42,7 +42,7 @@ The files must all be in `.pem` file format.
 
 ## Explanation
 
-You can encrypt network communication by using OpenSSL 1.0.x or 1.1.x (the JITServer technology feature currently does not support OpenSSL 3.0.x). To enable encryption, specify the private key (`<key>.pem`) and the certificate (`<cert>.pem`) at the server:
+You can encrypt network communication by using OpenSSL 1.0.x, 1.1.x, or 3.0.x. To enable encryption, specify the private key (`<key>.pem`) and the certificate (`<cert>.pem`) at the server:
 
     -XX:JITServerSSLKey=<key>.pem -XX:JITServerSSLCert=<cert>.pem
 


### PR DESCRIPTION
https://github.com/eclipse-openj9/openj9-docs/issues/930

Updated based on the review comment.

Updated the document to reflect the JITServer support for openssl 3.

Signed-off-by: Sreekala Gopakumar sreekala.gopakumar@ibm.com