### PR TITLE
Updated Windows jdk11 compilation uses VS2019

### DIFF
--- a/docs/openj9_support.md
+++ b/docs/openj9_support.md
@@ -251,7 +251,7 @@ The project builds and tests OpenJDK with OpenJ9 on a number of platforms. The o
 | Linux on POWER LE 64-bit      | CentOS 7.9             | gcc 7.5                               |
 | Linux on IBM Z 64-bit         | RHEL 7.9               | gcc 7.5                               |
 | Linux AArch64 64-bit          | CentOS 7.9             | gcc 7.5                               |
-| Windows x86 64-bit            | Windows Server 2012 R2 | Microsoft Visual Studio 2017          |
+| Windows x86 64-bit            | Windows Server 2012 R2 | Microsoft Visual Studio 2019          |
 | macOS x86 64-bit              | macOS 10.14.6          | xcode 10.3 and clang 10.0.1           |
 | AIX POWER BE 64-bit           | AIX 7.1 TL05           | xlc/C++ 16.1.0                        |
 

--- a/docs/version0.35.md
+++ b/docs/version0.35.md
@@ -35,6 +35,8 @@ The following new features and notable changes since version 0.33.1 are included
 
 OpenJ9 release 0.35.0 supports OpenJDK 8, 11, and 17.
 
+OpenJ9 Windows&reg; builds for OpenJDK 11 are now compiled with Microsoft&reg; Visual Studio 2019. The Visual Studio redistributable files included with the build are updated to match.
+
 To learn more about support for OpenJ9 releases, including OpenJDK levels and platform support, see [Supported environments](openj9_support.md).
 
 ### Java dump files contain more information about waiting threads


### PR DESCRIPTION
https://github.com/eclipse-openj9/openj9-docs/issues/981

Updated that the Windows jdk11 compilation now uses VS2019.

Signed-off-by: Sreekala Gopakumar <sreekala.gopakumar@ibm.com>