### PR TITLE
Document new -Xdump user2 event for the SIGUSR2 signal

### DIFF
--- a/docs/dump_javadump.md
+++ b/docs/dump_javadump.md
@@ -24,7 +24,7 @@
 
 # Java dump
 
-Java&reg; dumps, sometimes referred to as *Java cores*, are produced when the VM ends unexpectedly because of an operating system signal, `OutOfMemoryError`, or a user-initiated keystroke combination. You can also generate a Java dump by calling the Dump API programmatically from your application or specifying the `-Xdump:java` option on the command line.
+Java&trade; dumps, sometimes referred to as *Java cores*, are produced when the VM ends unexpectedly because of an operating system signal, `OutOfMemoryError`, or a user-initiated keystroke combination. You can also generate a Java dump by calling the Dump API programmatically from your application or specifying the `-Xdump:java` option on the command line.
 
 If your Java application crashes or hangs, Java dumps can provide useful information to help you diagnose the root cause.
 

--- a/docs/openj9_signals.md
+++ b/docs/openj9_signals.md
@@ -26,7 +26,7 @@
 
 Signals used by the OpenJ9 VM include the following types:
 
-- Exceptions (Exc): Raised synchronously by the operating system whenever an unrecoverable condition occurs (not applicable on Windows systems).
+- Exceptions (Exc): Raised synchronously by the operating system whenever an unrecoverable condition occurs (not applicable on Windows&trade; systems).
 - Errors (Err): Raised by the OpenJ9 VM when an unrecoverable condition occurs.
 - Interrupts (Int): Raised asynchronously from outside a VM process to request a VM exit.
 - Controls (Con): Other signals that are used by the VM for control purposes.
@@ -39,7 +39,7 @@ For exceptions and errors, if the VM cannot handle the condition and recover, du
 
 Control signals are used for internal control purposes and do not cause the VM to end.
 
-The VM takes control of any signals for Java threads. For non-Java threads, the VM passes control to an application handler, if one is installed. If the application does not install a signal handler, or signal chaining is turned off, the signal is either ignored or the default action is taken. Signal chaining is controlled by the [-Xsigchain / -Xnosigchain](xsigchain.md) command-line option.
+The VM takes control of any signals for Java&trade; threads. For non-Java threads, the VM passes control to an application handler, if one is installed. If the application does not install a signal handler, or signal chaining is turned off, the signal is either ignored or the default action is taken. Signal chaining is controlled by the [`-Xsigchain` / `-Xnosigchain`](xsigchain.md) command-line option.
 
 The signals relevant to each platform are detailed in the sections that follow.
 
@@ -59,10 +59,11 @@ Note that certain signals on VM threads cause OpenJ9 to shutdown. An application
 | `SIGINT (2)`      | Int  | Interactive attention (CTRL-C), VM exits normally                  | `-Xrs` |
 | `SIGTERM (15)`    | Int  | Termination request, VM exits normally                             | `-Xrs`  |
 | `SIGHUP (1)`      | Int  | Hang up, VM exits normally                                         | `-Xrs` |
+| `SIGUSR2 (12)`    | Int  | User-defined signal for triggering a dump agent                    | `-Xrs` |
 | `SIGQUIT (3)`     | Con  | Quit signal from a terminal, which triggers a Java dump by default | `-Xrs` |
 | `SIGTRAP (5)`     | Con  | Used by the JIT                                                    | `-Xrs` or `-Xrs:sync` |
 | `SIGRTMIN (34)`   | Con  | Used by the VM for thread introspection                       | - |
-| `SIGRTMIN +1 (35)`| Con  | Used by the VM for Runtime Instrumentation (Linux for IBM Z systems only)| - |
+| `SIGRTMIN +1 (35)`| Con  | Used by the VM for Runtime Instrumentation (Linux for IBM Z&reg; systems only)| - |
 | `SIGRTMAX -2 (62)`| Con  | Used by the `java.net` class library code                                         | - |
 | `SIGCHLD (17)`    | Con  | Used by the `java.lang.Process` implementation                     | - |
 
@@ -83,6 +84,7 @@ Note that certain signals on VM threads cause OpenJ9 to shutdown. An application
 | `SIGINT (2)`      | Int  | Interactive attention (CTRL-C), VM exits normally                  | `-Xrs` |
 | `SIGTERM (15)`    | Int  | Termination request, VM exits normally                             | `-Xrs` |
 | `SIGHUP (1)`      | Int  | Hang up, VM exits normally                                         | `-Xrs` |
+| `SIGUSR2 (31)`    | Int  | User-defined signal for triggering a dump agent                    | `-Xrs` |
 | `SIGQUIT (3)`     | Con  | Quit signal from a terminal, which triggers a Java dump by default | `-Xrs` |
 | `SIGTRAP (5)`     | Con  | Used by the JIT                                                    | `-Xrs` or `-Xrs:sync` |
 | `SIGCHLD (20)`    | Con  | Used by the `java.lang.Process` implementation                     | - |
@@ -92,7 +94,6 @@ Note that certain signals on VM threads cause OpenJ9 to shutdown. An application
 :fontawesome-solid-pencil-alt:{: .note aria-hidden="true"} **Note:**
 
 - The handling of `SIGABRT` is configurable with the `-XX[+|-]HandleSIGABRT` option.
-
 
 ## Signals on Windows
 
@@ -112,7 +113,6 @@ The following mechanisms are used by OpenJ9 for signal handling:
 
 All mechanisms can be disabled by using the `-Xrs` option. However, only structured exception handling and the use of the `AddVectoredExceptionHandler()` API can be disabled  by using the `-Xrs:sync` option. The option `-Xnosigchain`, which turns off signal handler chaining, is ignored on Windows systems.
 
-
 ## Signals on z/OS
 
 | Signal            | Type | Description                                                        | Option to disable signal  |
@@ -125,12 +125,13 @@ All mechanisms can be disabled by using the `-Xrs` option. However, only structu
 | `SIGINT (2)`      | Int  | Interactive attention (CTRL-C), VM exits normally                  | `-Xrs` |
 | `SIGTERM (15)`    | Int  | Termination request, VM exits normally                             | `-Xrs` |
 | `SIGHUP (1)`      | Int  | Hang up, VM exits normally                                         | `-Xrs` |
+| `SIGUSR2 (17)`    | Int  | User-defined signal for triggering a dump agent                    | `-Xrs` |
 | `SIGQUIT (24)`    | Con  | Quit signal from a terminal, triggers a Java dump by default       | `-Xrs` |
 | `SIGTRAP (26)`    | Con  | Used by the JIT                                                    | `-Xrs` or `-Xrs:sync` |
 | `SIGCHLD (20)`    | Con  | Used by the `java.lang.Process` implementation                     | - |
 | `SIGUSR1 (16)`    | Con  | Used by the `java.net` class library code                          | - |
 
-:fontawesome-solid-pencil-alt:{: .note aria-hidden="true"} **Notes:**
+:fontawesome-solid-pencil-alt:{: .note aria-hidden="true"} **Note:**
 
 - The handling of `SIGABRT` is configurable with the `-XX[+|-]HandleSIGABRT` option.
 
@@ -146,6 +147,7 @@ All mechanisms can be disabled by using the `-Xrs` option. However, only structu
 | `SIGINT (2)`      | Int  | Interactive attention (CTRL-C), VM exits normally                  | `-Xrs` |
 | `SIGTERM (15)`    | Int  | Termination request, VM exits normally                             | `-Xrs`  |
 | `SIGHUP (1)`      | Int  | Hang up, VM exits normally                                         | `-Xrs` |
+| `SIGUSR2 (31)`    | Int  | User-defined signal for triggering a dump agent                    | `-Xrs` |
 | `SIGQUIT (3)`     | Con  | Triggers a Java dump by default                                    | `-Xrs` |
 | `No Name (40)`    | Con  | Used by the VM for control purposes                                | `-Xrs` |
 | `SIGRECONFIG (58)`| Con  | Reserved to detect changes to resources (CPUs, processing capacity, or physical memory)| `-Xrs` |
@@ -172,7 +174,7 @@ command line syntax to use with the compiler, where available:
 
 |Operating system        | Shared library | Method for linking |
 |------------------------|----------------|--------------------|
-| Linux, macOS, and z/OS | `libjsig.so`   | `gcc -L$JAVA_HOME/bin -ljsig -L$JAVA_HOME/lib/j9vm -ljvm <java_application>.c` |
+| Linux&reg;, macOS&reg;, and z/OS&reg; | `libjsig.so`   | `gcc -L$JAVA_HOME/bin -ljsig -L$JAVA_HOME/lib/j9vm -ljvm <java_application>.c` |
 | Windows                | `jsig.dll`     | Link the DLL with the application that creates or embeds a VM |
 | AIX                    | `libjsig.so`   | `cc_r [-q64] <other_compile/link_parameter> -L<java_install_dir> -ljsig -L<java_install_dir>/lib/j9vm -ljvm <java_application>.c` |
 

--- a/docs/version0.35.md
+++ b/docs/version0.35.md
@@ -27,8 +27,9 @@
 The following new features and notable changes since version 0.33.1 are included in this release:
 
 - [New binaries and changes to supported environments](#binaries-and-supported-environments)
-- [Java&reg; dump files contain more information about waiting threads](#java-dump-files-contain-more-information-about-waiting-threads)
-- [New `-XX:[+|-]ShowNativeStackSymbols` option added](#new-xx-shownativestacksymbols-option-added)
+- [Java&trade; dump files contain more information about waiting threads](#java-dump-files-contain-more-information-about-waiting-threads)
+- [New `-XX:[+|-]ShowNativeStackSymbols` option added](#new--xx-shownativestacksymbols-option-added)
+- [New `user2` event added for the `-Xdump` option](#new-user2-event-added-for-the--xdump-option)
 
 ## Features and changes
 
@@ -53,6 +54,14 @@ For more information, see [Threads](dump_javadump.md#threads).
 This option controls whether Java dumps show the names of functions in native call stacks.
 
 For more information, see [`-XX:[+|-]ShowNativeStackSymbols`](xxshownativestacksymbols.md).
+
+### New `user2` event added for the `-Xdump` option
+
+On operating systems other than Windows&trade;, you can now use the `user2` event for the `-Xdump` option. This event is triggered when the VM receives the `SIGUSR2` signal.
+
+There is a change in the `SIGUSR2` signal behavior as well whereby, the process does not exit in response to this signal.
+
+For more information, see [`-Xdump`](xdump.md#dump-events) and [Signal handling](openj9_signals.md).
 
 ## Known problems and full release information
 

--- a/docs/xdump.md
+++ b/docs/xdump.md
@@ -88,7 +88,7 @@ java -Xdump:heap:none -Xdump:heap+java:events=vmstart+vmstop -mp . -m <class> [a
 java -Xdump:java:events=vmstart,file=/STDERR/ -version
 ```
 
-For more detailed information on the these parameters and suboptions, including examples, see [Parameters](#parameters).
+For more detailed information on these parameters and suboptions, including examples, see [Parameters](#parameters).
 
 ## Dump agents
 
@@ -189,7 +189,7 @@ You can use tokens to add context to dump file names and directories, and to pas
 | %y    | Year (2 digits)                                                                                                               |
 | %m    | Month (2 digits)                                                                                                              |
 | %d    | Day of the month (2 digits)                                                                                                   |
-| %H    | Hour ( 2 digits)                                                                                                              |
+| %H    | Hour (2 digits)                                                                                                              |
 | %M    | Minute (2 digits)                                                                                                             |
 | %S    | Second (2 digits)                                                                                                             |
 | %home | Java home directory                                                                                                           |
@@ -211,7 +211,7 @@ The following tokens are applicable only to z/OS:
 
 ### Merging dump agents
 
-If you configure more than one dump agent, each responds to events according to its configuration. However, the internal structures representing the dump agent configuration might not match the command line, because dump agents are merged for efficiency. Two sets of options can be merged as long as none of the agent settings conflict. This means that the list of installed dump agents and their parameters produced by `-Xdump:what` might not be grouped in the same way as the original `-Xdump` options that configured them.
+If you configure more than one dump agent, each responds to events according to its configuration. However, the internal structures representing the dump agent configuration might not match the command line because dump agents are merged for efficiency. Two sets of options can be merged as long as none of the agent settings conflict. This means that the list of installed dump agents and their parameters produced by `-Xdump:what` might not be grouped in the same way as the original `-Xdump` options that configured them.
 
 
 For example, you can use the following command to specify that a dump agent creates a Java dump file on class unload:
@@ -289,10 +289,11 @@ Dump agents are triggered by events occurring during operation of the OpenJ9 VM.
 
 The following table shows the events that are available as dump agent triggers:
 
-| Event           |  Triggered when....                                                         | Filters on ....                                                |
+| Event           |  Triggered when....                                                         | Filters on....                                                |
 | ----------------|-----------------------------------------------------------------------------|----------------------------------------------------------------|
 | **gpf**         | A General Protection Fault (GPF) occurs.                                    | Not applicable                                                 |
 | **user**        | The VM receives the SIGQUIT (Linux, macOS&reg;, AIX&reg;, z/OS) or SIGBREAK (Windows&trade;) signal from the operating system.|  Not applicable                      |
+| **user2**       | The VM receives the SIGUSR2 (Linux, AIX, z/OS, and macOS) signal from the operating system.               | Not applicable                                                 |
 | **abort**       | The VM receives the SIGABRT signal from the operating system.               | Not applicable                                                 |
 | **vmstart**     | The virtual machine is started.                                             | Not applicable                                                 |
 | **vmstop**      | The virtual machine stops.                                                  | Exit code; for example, `filter=#129..#192#-42#255`            |
@@ -306,13 +307,20 @@ The following table shows the events that are available as dump agent triggers:
 | **blocked**     | A thread becomes blocked.                                                   | Not applicable                                                 |
 | **thrstop**     | A thread stops.                                                             | Not applicable                                                 |
 | **fullgc**      | A garbage collection cycle is started.                                      | Not applicable                                                 |
-| **slow**        | A thread takes longer than 50ms to respond to an internal VM request.       | Time taken; for example, filter=#300ms will trigger when a thread takes longer than 300ms to respond to an internal VM request.|
-| **allocation**  | A Java object is allocated with a size matching the given filter specification.| Object size; a filter must be supplied. For example, filter=#5m will trigger on objects larger than 5 Mb. Ranges are also supported; for example, filter=#256k..512k will trigger on objects between 256 Kb and 512 Kb in size.|
+| **slow**        | A thread takes longer than 50 ms to respond to an internal VM request.       | Time taken; for example, filter=#300ms will trigger when a thread takes longer than 300 ms to respond to an internal VM request.|
+| **allocation**  | A Java object is allocated with a size matching the given filter specification.| Object size; a filter must be supplied. For example, filter=#5m will trigger on objects larger than 5 Mb. Ranges are also supported; for example, filter=#256k..512k will trigger on objects 256 - 512 Kb in size.|
 | **traceassert** | An internal error occurs in the VM.                                         | Not applicable                                                 |
 | **corruptcache**| The VM finds that the shared classes cache is corrupt.                      | Not applicable                                                 |
 | **excessivegc** | An excessive amount of time is being spent in the garbage collector.        | Not applicable                                                 |
 
-:fontawesome-solid-pencil-alt:{: .note aria-hidden="true"} **Note:** The **gpf**, **traceassert**, and **abort** events cannot trigger a heap dump, prepare the heap (request=prepwalk), or compact the heap (request=compact).
+:fontawesome-solid-pencil-alt:{: .note aria-hidden="true"} **Notes:**
+- The **gpf**, **traceassert**, and **abort** events cannot trigger a heap dump, prepare the heap (request=prepwalk), or compact the heap (request=compact).
+- The Java dump agent behaves differently when triggered by the `user` and `user2` events. For more information, see [`request=<requests>`](#requestrequests).
+- The `user2` event is commonly used for taking system dump files with exclusive access without overriding the `user` event, which is generally left for taking Java dump files for performance investigations. For example:
+
+```
+-Xdump:system:events=user2,request=exclusive+prepwalk
+```
 
 ## Parameters
 
@@ -399,7 +407,7 @@ Or, for example, on z/OS, you can add the jobname to the Java dump file name usi
 
 This option does not add a Java dump agent; it updates the default settings for Java dump agents. Further Java dump agents will then create dump files using this specification for filenames, unless overridden.
 
-:fontawesome-solid-pencil-alt:{: .note aria-hidden="true"} **Note:** Changing the defaults for a dump type will also affect the default agents for that dump type added by the VM during initialization. For example if you change the default file name for Java dump files, that will change the file name used by the default Java dump agents. However, changing the default range option will not change the range used by the default Java dump agents, because those agents override the range option with specific values.
+:fontawesome-solid-pencil-alt:{: .note aria-hidden="true"} **Note:** Changing the defaults for a dump type will also affect the default agents for that dump type added by the VM during initialization. For example, if you change the default file name for Java dump files, that will change the file name used by the default Java dump agents. However, changing the default range option will not change the range used by the default Java dump agents, because those agents override the range option with specific values.
 
 ### `events=<event>`
 
@@ -580,7 +588,7 @@ For example, to trigger dumps on allocations greater than 5 Mb in size, use:
 -Xdump:stack:events=allocation,filter=#5m
 ```
 
-To trigger dumps on allocations between 256Kb and 512Kb in size, use:
+To trigger dumps on allocations between 256 Kb and 512 Kb in size, use:
 
 ```
 -Xdump:stack:events=allocation,filter=#256k..512k
@@ -601,7 +609,7 @@ Use the following syntax to include message filtering in your dump output:
 ```
 where `<filter>` is a text string from the exceptions that you want to include in the dump file. This suboption supports asterisks as wild cards.
 
-The following example filters `java/lang/VerifyError` exceptions that contains the text string *class format*:
+The following example filters `java/lang/VerifyError` exceptions that contain the text string *class format*:
 
 ```
 -Xdump:java:events=throw,filter=java/lang/VerifyError,msg_filter=*class format*
@@ -665,7 +673,7 @@ This option starts the process, waits for the process to end, and then waits a f
 -Xdump:tool:events=vmstop,exec=myProgram,opts=ASYNC+WAIT10000
 ```
 
-Finally the last example starts the process and waits for 10 seconds before continuing, whether the process is still running or not. This last form is useful if you are starting a process that does not end, but requires time to initialize properly.
+Finally, the last example starts the process and waits for 10 seconds before continuing, whether the process is still running or not. This last form is useful if you are starting a process that does not end, but requires time to initialize properly.
 
 ### `priority=<0-999>`
 
@@ -753,6 +761,21 @@ The default setting of the `request` suboption for Java dump files is `request=e
 ```
 -Xdump:java:request=exclusive
 ```
+
+The Java dump agent ignores the `request=exclusive` setting if a `user` event occurs and another event already has exclusive access. In this scenario, the Java dump agent shares the access instead. This behavior is useful because it allows you to obtain a Java dump file during a deadlock situation, when exclusive access is not released. However, the resulting Java dump file, even in other situations, might omit thread stacks and contain inconsistent thread information, as indicated by the following line in the file:
+
+```
+1TIPREPINFO    Exclusive VM access not taken: data may not be consistent across javacore sections
+```
+
+On operating systems other than Windows, you can enforce exclusive access and obtain a complete dump file by specifying that the `user2` event triggers the Java dump agent instead of the `user` event. For example:
+
+```
+-Xdump:java:events=user2,request=exclusive+prepwalk
+```
+When a `user2` event occurs, for example, when you enter `kill -USR2 <pid>` on the command line, the Java dump agent accepts the `request=exclusive` setting and waits for exclusive access before creating the Java dump file.
+
+For more information about events, see [Dump events](#dump-events).
 
 In general, the default request options are sufficient.
 


### PR DESCRIPTION
https://github.com/eclipse-openj9/openj9-docs/issues/978

Updated the dump events list with user2 event. Explained the behavior.

Signed-off-by: Sreekala Gopakumar <sreekala.gopakumar@ibm.com>