### PR TITLE
Encryption of custom metrics exported by JITServer

### DIFF
--- a/docs/jitserver_tuning.md
+++ b/docs/jitserver_tuning.md
@@ -120,6 +120,8 @@ You can enable the provision of performance metrics by specifying the `-XX:+JITS
 
 :fontawesome-solid-pencil-alt:{: .note aria-hidden="true"} **Note:** There is a limit of four concurrent `GET` requests at any given time.
 
+You can use the [`-XX:JITServerMetricsSSLKey`](xxjitservermetricssslkey.md) and [`-XX:JITServerMetricsSSLCert`](xxjitservermetricssslkey.md) options to encrypt the data with TLS or SSL.
+
 For more information, including the types of metrics that are provided, see the [`-XX:[+|-]JITServerMetrics`](xxjitservermetrics.md) topic.
 
 ### Verbose logging

--- a/docs/version0.35.md
+++ b/docs/version0.35.md
@@ -32,6 +32,7 @@ The following new features and notable changes since version 0.33.1 are included
 - [New `user2` event added for the `-Xdump` option](#new-user2-event-added-for-the-xdump-option)
 - [New `-XX:[+|-]PerfTool` option added](#new-xx-perftool-option-added)
 - [New default options added in the `options.default` file](#new-default-options-added-in-the-optionsdefault-file)
+- [New options added to encrypt the JITServer metrics](#new-options-added-to-encrypt-the-jitserver-metrics)
 
 ## Features and changes
 
@@ -78,6 +79,10 @@ For more information, see [`-XX:[+|-]PerfTool`](xxperftool.md).
 `-XX:+EnsureHashed:java/lang/Class,java/lang/Thread` is added to the list of default options in the `options.default` file to improve performance.
 
 For more information, see [`XX:[+|-]EnsureHashed`](xxensurehashed.md).
+
+### New options added to encrypt the JITServer metrics
+
+You can use the [`-XX:JITServerMetricsSSLKey`](xxjitservermetricssslkey.md) and [`-XX:JITServerMetricsSSLCert`](xxjitservermetricssslkey.md) options to encrypt the custom metrics with TLS or SSL.
 
 ## Known problems and full release information
 

--- a/docs/xxjitservermetrics.md
+++ b/docs/xxjitservermetrics.md
@@ -33,7 +33,7 @@ When you enable this option, the following JITServer metrics are provided:
 - The number of clients that are connected to the JITServer
 - The number of active compilation threads in the JITServer
 
-:fontawesome-solid-pencil-alt:{: .note aria-hidden="true"} **Note:** The data is currently not encrypted.
+:fontawesome-solid-pencil-alt:{: .note aria-hidden="true"} **Note:** You can use the [`-XX:JITServerMetricsSSLKey`](xxjitservermetricssslkey.md) and [`-XX:JITServerMetricsSSLCert`](xxjitservermetricssslkey.md) options for encrypting the data with SSL or TLS.
 
 ## Syntax
 
@@ -88,5 +88,6 @@ JITServer response:
 
 - [-XX:JITServerMetricsPort](xxjitservermetricsport.md)
 - [JITServer technology](jitserver.md)
+- [`-XX:JITServerMetricsSSLKey`](xxjitservermetricssslkey.md)
 
 <!-- ==== END OF TOPIC ==== xxjitservermetrics.md ==== -->

--- a/docs/xxjitservermetricssslkey.md
+++ b/docs/xxjitservermetricssslkey.md
@@ -1,0 +1,57 @@
+<!--
+* Copyright (c) 2017, 2022 IBM Corp. and others
+*
+* This program and the accompanying materials are made
+* available under the terms of the Eclipse Public License 2.0
+* which accompanies this distribution and is available at
+* https://www.eclipse.org/legal/epl-2.0/ or the Apache
+* License, Version 2.0 which accompanies this distribution and
+* is available at https://www.apache.org/licenses/LICENSE-2.0.
+*
+* This Source Code may also be made available under the
+* following Secondary Licenses when the conditions for such
+* availability set forth in the Eclipse Public License, v. 2.0
+* are satisfied: GNU General Public License, version 2 with
+* the GNU Classpath Exception [1] and GNU General Public
+* License, version 2 with the OpenJDK Assembly Exception [2].
+*
+* [1] https://www.gnu.org/software/classpath/license.html
+* [2] http://openjdk.java.net/legal/assembly-exception.html
+*
+* SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH
+* Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+-->
+
+# -XX:JITServerMetricsSSLKey / -XX:JITServerMetricsSSLCert
+
+These options specify the names of the files that contain the private TLS or SSL key and certificate that are used for authentication and encryption of the custom metrics.
+
+## Syntax
+
+        -XX:JITServerMetricsSSLKey=<key_file>
+        -XX:JITServerMetricsSSLCert=<cert_file>
+
+Where `<key_file>` specifies the name of the file that contains the private TLS or SSL key and `<cert_file>` specifies the name of the file that contains the private TLS or SSL certificate.
+The files must all be in `.pem` file format.
+
+| Setting                 | Effect | Default                                                                            |
+|-------------------------|--------|:----------------------------------------------------------------------------------:|
+|` -XX:JITServerMetricsSSLKey`           | Set metrics SSL key | None                                                                                    |
+|`-XX:JITServerMetricsSSLCert`           | Set metrics SSL certificate | None                                                                                    |
+
+## Explanation
+
+Custom metrics are exported by the JITServer server and collected by a monitoring agent, such as Prometheus. The exported data is sent in clear text by default. To secure this data with TLS or SSL authentication and encryption, specify the private key (`<key>.pem`) and the certificate (`<cert>.pem`) at the server:
+
+        -XX:JITServerMetricsSSLKey=<key>.pem -XX:JITServerMetricsSSLCert=<cert>.pem
+
+You must specify both the options for TLS or SSL authentication and encryption.
+
+:fontawesome-solid-pencil-alt:{: .note aria-hidden="true"} **Note:** To enable the export of custom metrics, you must specify the [`-XX:[+|-]JITServerMetrics`](xxjitservermetrics.md) option.
+
+## See also
+
+- [-XX:[+|-]JITServerMetrics](xxjitservermetrics.md)
+- [JITServer technology](jitserver.md)
+
+<!-- ==== END OF TOPIC ==== xxjitservermetricssslkey.md ==== -->

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -387,6 +387,8 @@ nav:
             - "-XX:[+|-]JITServerLogConnections"                                 : xxjitserverlogconnections.md
             - "-XX:JITServerMetrics"                                             : xxjitservermetrics.md
             - "-XX:JITServerMetricsPort"                                         : xxjitservermetricsport.md
+            - "-XX:JITServerMetricsSSLCert"                                      : xxjitservermetricssslkey.md
+            - "-XX:JITServerMetricsSSLKey"                                       : xxjitservermetricssslkey.md
             - "-XX:JITServerPort"                                                : xxjitserverport.md
             - "-XX:JITServerShareROMClasses"                                     : xxjitservershareromclasses.md
             - "-XX:JITServerSSLCert"                                             : xxjitserversslcert.md


### PR DESCRIPTION
https://github.com/eclipse-openj9/openj9-docs/issues/1000

Added -XX:JITServerMetricsSSLKey and -XX:JITServerMetricsSSLCert options Updated the related topics

Signed-off-by: Sreekala Gopakumar <sreekala.gopakumar@ibm.com>