### PR TITLE
AIX Java 11+ requires XL C++ Runtime 16.1.0.7 or later

### DIFF
--- a/docs/openj9_support.md
+++ b/docs/openj9_support.md
@@ -141,7 +141,7 @@ OpenJDK 11 binaries are expected to function on the minimum operating system lev
 | AIX 7.1 TL5                               | :fontawesome-solid-check:{: .yes aria-hidden="true"}<span class="sr-only">yes</span> |
 | AIX 7.2 TL4                               | :fontawesome-solid-check:{: .yes aria-hidden="true"}<span class="sr-only">yes</span> |
 
-:fontawesome-solid-bell:{: .warn aria-hidden="true"} **Important:** AIX OpenJ9 builds require the [16.1 XL C++ Runtime](https://www.ibm.com/support/pages/fix-list-xl-cc-runtime-aix#161X).
+:fontawesome-solid-bell:{: .warn aria-hidden="true"} **Important:** AIX OpenJ9 builds require the [XL C++ Runtime 16.1.0.7 or later](https://www.ibm.com/support/pages/fix-list-xl-cc-runtime-aix#161X).
 
 When public support for an operating system version ends, OpenJ9 can no longer be supported on that level.
 
@@ -181,7 +181,7 @@ OpenJDK 17 binaries are expected to function on the minimum operating system lev
 | AIX 7.1 TL5                               | :fontawesome-solid-check:{: .yes aria-hidden="true"}<span class="sr-only">yes</span> |
 | AIX 7.2 TL4                               | :fontawesome-solid-check:{: .yes aria-hidden="true"}<span class="sr-only">yes</span> |
 
-:fontawesome-solid-bell:{: .warn aria-hidden="true"} **Important:** AIX OpenJ9 builds require the [16.1 XL C++ Runtime](https://www.ibm.com/support/pages/fix-list-xl-cc-runtime-aix#161X).
+:fontawesome-solid-bell:{: .warn aria-hidden="true"} **Important:** AIX OpenJ9 builds require the [XL C++ Runtime 16.1.0.7 or later](https://www.ibm.com/support/pages/fix-list-xl-cc-runtime-aix#161X).
 
 When public support for an operating system version ends, OpenJ9 can no longer be supported on that level.
 
@@ -221,7 +221,7 @@ OpenJDK 18 binaries are expected to function on the minimum operating system lev
 | AIX 7.1 TL5                               | :fontawesome-solid-check:{: .yes aria-hidden="true"}<span class="sr-only">yes</span> |
 | AIX 7.2 TL4                               | :fontawesome-solid-check:{: .yes aria-hidden="true"}<span class="sr-only">yes</span> |
 
-:fontawesome-solid-bell:{: .warn aria-hidden="true"} **Important:** AIX OpenJ9 builds require the [16.1 XL C++ Runtime](https://www.ibm.com/support/pages/fix-list-xl-cc-runtime-aix#161X).
+:fontawesome-solid-bell:{: .warn aria-hidden="true"} **Important:** AIX OpenJ9 builds require the [XL C++ Runtime 16.1.0.7 or later](https://www.ibm.com/support/pages/fix-list-xl-cc-runtime-aix#161X).
 
 When public support for an operating system version ends, OpenJ9 can no longer be supported on that level.
 

--- a/docs/version0.35.md
+++ b/docs/version0.35.md
@@ -32,6 +32,7 @@ The following new features and notable changes since version 0.33.1 are included
 - [New `user2` event added for the `-Xdump` option](#new-user2-event-added-for-the-xdump-option)
 - [New `-XX:[+|-]PerfTool` option added](#new-xx-perftool-option-added)
 - [New default options added in the `options.default` file](#new-default-options-added-in-the-optionsdefault-file)
+- ![Start of content that applies to Java 11 and later](cr/java11plus.png) [XL C++ Runtime 16.1.0.7 or later required on AIX](#xl-c-runtime-16107-or-later-required-on-aix)
 
 ## Features and changes
 
@@ -78,6 +79,10 @@ For more information, see [`-XX:[+|-]PerfTool`](xxperftool.md).
 `-XX:+EnsureHashed:java/lang/Class,java/lang/Thread` is added to the list of default options in the `options.default` file to improve performance.
 
 For more information, see [`XX:[+|-]EnsureHashed`](xxensurehashed.md).
+
+### ![Start of content that applies to Java 11 and later](cr/java11plus.png) XL C++ Runtime 16.1.0.7 or later required on AIX
+
+AIX OpenJ9 builds now require version 16.1.0.7 or later of the [IBM XL C++ Runtime](https://www.ibm.com/support/pages/fix-list-xl-cc-runtime-aix#161X).
 
 ## Known problems and full release information
 


### PR DESCRIPTION
Closes https://github.com/eclipse-openj9/openj9-docs/issues/1005

Updated the Supported environments topic and the What's new in version 0.35.0 topic.

Signed-off-by: Sreekala Gopakumar <sreekala.gopakumar@ibm.com>