### PR TITLE
Default status of -XX:[+\-]JITServerLocalSyncCompiles

### DIFF
--- a/docs/version0.35.md
+++ b/docs/version0.35.md
@@ -34,6 +34,7 @@ The following new features and notable changes since version 0.33.1 are included
 - [New default options added in the `options.default` file](#new-default-options-added-in-the-optionsdefault-file)
 - [New options added to encrypt the JITServer exported metrics](#new-options-added-to-encrypt-the-jitserver-exported-metrics)
 - ![Start of content that applies to Java 11 and later](cr/java11plus.png) [XL C++ Runtime 16.1.0.7 or later required on AIX](#xl-c-runtime-16107-or-later-required-on-aix)
+- [`-XX:[+|-]JITServerLocalSyncCompiles` enabled by default](#-xx-jitserverlocalsynccompiles-enabled-by-default)
 
 ## Features and changes
 
@@ -88,6 +89,10 @@ You can use the [`-XX:JITServerMetricsSSLKey`](xxjitservermetricssslkey.md) and 
 ### ![Start of content that applies to Java 11 and later](cr/java11plus.png) XL C++ Runtime 16.1.0.7 or later required on AIX
 
 AIX OpenJ9 builds now require version 16.1.0.7 or later of the [IBM XL C++ Runtime](https://www.ibm.com/support/pages/fix-list-xl-cc-runtime-aix#161X).
+
+### `-XX:[+|-]JITServerLocalSyncCompiles` enabled by default
+
+The `-XX:[+|-]JITServerLocalSyncCompiles` option is now enabled by default in most cases. For more information, see [`-XX:[+|-]JITServerLocalSyncCompiles`](xxjitserverlocalsynccompiles.md).
 
 ## Known problems and full release information
 

--- a/docs/xxjitserverlocalsynccompiles.md
+++ b/docs/xxjitserverlocalsynccompiles.md
@@ -30,10 +30,12 @@ When you specify this JITServer option, synchronous JIT compilations are downgra
 
         -XX:[+|-]JITServerLocalSyncCompiles
 
-| Setting                 | Effect | Default                                                                            |
+| Setting                 | Effect | Default                                                                             |
 |-------------------------|--------|:----------------------------------------------------------------------------------:|
-|`-XX:+JITServerLocalSyncCompiles`           | Enable |                                                                                    |
-|`-XX:-JITServerLocalSyncCompiles`           | Disable| :fontawesome-solid-check:{: .yes aria-hidden="true"}<span class="sr-only">yes</span> |
+|`-XX:+JITServerLocalSyncCompiles`           | Enable |  :fontawesome-solid-check:{: .yes aria-hidden="true"}<span class="sr-only">yes</span>                                                          |
+|`-XX:-JITServerLocalSyncCompiles`           | Disable|                             |
+
+The option `-XX:[+|-]JITServerLocalSyncCompiles` is enabled by default in most cases. The option remains disabled when you specify [`-Xjit:count=0`](xjit.md#count) and in a few advanced use cases such as running the JVM in debug mode (as described in the [Improved JVM debug mode based on OSR](https://blog.openj9.org/2019/04/30/introduction-to-full-speed-debug-base-on-osr/) post in the Eclipse OpenJ9&trade; blog).
 
 ## Explanation
 


### PR DESCRIPTION
https://github.com/eclipse-openj9/openj9-docs/issues/1001

Updated the default status of the -XX:[+\-]JITServerLocalSyncCompiles option.

Signed-off-by: Sreekala Gopakumar <sreekala.gopakumar@ibm.com>