### PR TITLE
JSR 337 Maintenance Release 4 - Phantom reference

### DIFF
--- a/docs/gc_overview.md
+++ b/docs/gc_overview.md
@@ -199,7 +199,7 @@ cleared. For example, a software cache. The garbage collector handles the refere
 |----------------|----------------------------------|----------------------------|
 | soft         | `java.lang.ref.SoftReference`    | A soft reference is cleared only when its *referent* is not marked for a number of GC cycles or if space on the heap is likely to cause an out of memory error. Use the [-Xsoftrefthreshold](xsoftrefthreshold.md) option to control the collection of soft reference objects. |
 | weak         | `java.lang.ref.WeakReference`    | A weak reference is cleared as soon as its *referent* is not marked by a GC cycle. |
-| phantom      | `java.lang.ref.PhantomReference` | A phantom reference is added to a reference queue and cleared after any objects that require finalization. |  
+| phantom      | `java.lang.ref.PhantomReference` | A phantom reference is cleared automatically as soon as its *referent* is not marked by a GC cycle. The cleared reference is then added to the associated reference queue at the same time or later. |
 
 If your application uses the Java Native Interface (JNI) to interact with other application types, you can also create weak JNI object references. These references have a similar life cycle to a weak Java reference. The garbage collector processes weak JNI references after all other Java reference types.
 

--- a/docs/version0.35.md
+++ b/docs/version0.35.md
@@ -35,6 +35,7 @@ The following new features and notable changes since version 0.33.1 are included
 - [New options added to encrypt the JITServer exported metrics](#new-options-added-to-encrypt-the-jitserver-exported-metrics)
 - ![Start of content that applies to Java 11 and later](cr/java11plus.png) [XL C++ Runtime 16.1.0.7 or later required on AIX](#xl-c-runtime-16107-or-later-required-on-aix)
 - [`-XX:[+|-]JITServerLocalSyncCompiles` enabled by default](#-xx-jitserverlocalsynccompiles-enabled-by-default)
+- ![Start of content that applies to Java 8](cr/java8.png) [Support for changes to the maintenance specifications of JSR 337 in Java 8](#support-for-changes-to-the-maintenance-specifications-of-jsr-337-in-java-8)
 
 ## Features and changes
 
@@ -93,6 +94,12 @@ AIX OpenJ9 builds now require version 16.1.0.7 or later of the [IBM XL C++ Runti
 ### `-XX:[+|-]JITServerLocalSyncCompiles` enabled by default
 
 The `-XX:[+|-]JITServerLocalSyncCompiles` option is now enabled by default in most cases. For more information, see [`-XX:[+|-]JITServerLocalSyncCompiles`](xxjitserverlocalsynccompiles.md).
+
+### ![Start of content that applies to Java 8](cr/java8.png) Support for changes to the maintenance specifications of JSR 337 in Java 8
+
+OpenJ9 now supports changes to the maintenance specifications in Java 8 as listed in the [JSR 337 Maintenance Release 4](https://jcp.org/aboutJava/communityprocess/maintenance/jsr337/jsr337-mr4-changes.html) document.
+
+These changes include the change in the garbage collector behavior for handling the phantom references in Java 8. The garbage collector handles both the phantom as well as the weak references similarly, which is the current behavior in Java 11 and later. For more information, see [Weak reference processing](gc_overview.md#weak-reference-processing).
 
 ## Known problems and full release information
 


### PR DESCRIPTION
https://github.com/eclipse-openj9/openj9-docs/issues/1017

Added information about the change in the GC behaviour in handling the phantom reference.

Signed-off-by: Sreekala Gopakumar <sreekala.gopakumar@ibm.com>