### PR TITLE
JITServer AOT cache memory limit option

### DIFF
--- a/docs/jitserver.md
+++ b/docs/jitserver.md
@@ -69,6 +69,7 @@ You can use command line options to further configure the JITServer and the clie
 - [`-XX:JITServerMetricsPort=<port>`](xxjitservermetricsport.md): Specifies the port number on which the JITServer metrics are provided to a monitoring agent
 - [`-XX:JITServerAOTCacheName=<cache_name>`](xxjitserveraotcachename.md): Specifies the name of the server-side AOT cache to use
 - [`-XX:[+|-]JITServerUseAOTCache`](xxjitserveruseaotcache.md): Specifies whether the server caches AOT-compiled methods
+- [`-XX:JITServerAOTmx=<size>`](xxjitserveraotmx.md): Specifies the maximum amount of memory that can be used by the JITServer AOT cache
 
 If a JITServer server crashes, the client is forced to perform compilations locally. You can change this behavior by using the [`-XX:[+|-]RequireJITServer`](xxrequirejitserver.md) option so that the client crashes with an assert when it detects that the server is unavailable. This feature is useful when you are running a test suite with JITServer enabled and you want the server crash to cause the test to fail.
 

--- a/docs/jitserver_tuning.md
+++ b/docs/jitserver_tuning.md
@@ -42,11 +42,12 @@ The client-session caches are deleted when the clients terminate, but this can h
 
  To enable this feature, specify the [`-XX:+JITServerUseAOTCache`](xxjitserveruseaotcache.md) command line option, both at the server and at the client JVM.
 
- A JITServer instance can have several AOT caches, each with its own name. This addresses the situation when client JVMs with significantly different profiles of execution use the same JITServer instance. A client JVM can indicate a specific AOT cache it wants to use by providing its name with the following command line option [`-XX:JITServerAOTCacheName=<cache_name>`](xxjitserveraotcachename.md). The default is to use a nameless cache.
+ A JITServer instance can have several AOT caches, each with its own name. This addresses the situation when client JVMs with significantly different profiles of execution use the same JITServer instance. A client JVM can indicate a specific AOT cache it wants to use by providing its name with the following command line option [`-XX:JITServerAOTCacheName=<cache_name>`](xxjitserveraotcachename.md). If the client doesn't specify a name for the AOT cache, the server uses a cache named `default`.
+
+ The maximum amount of memory that all the AOT cache instances combined can use at the server is 300 MB, by default. You can change this value by using the [`-XX:JITServerAOTmx=<size>`](xxjitserveraotmx.md) option. When the cache size reaches the specified limit, new clients cannot create new AOT cache instances or add new compiled methods to the existing AOT cache instances.
 
  Current limitations:
 
- - The amount of memory that an AOT cache can consume at the server is not limited. The number of caches that a JITServer can hold is also not limited.
  - The AOT cache is a non-persistent in-memory cache. If the JITServer instance ends, the cache content is lost.
  - AOT cache entries are not shared between different JITServer instances.
  - Caching works only for AOT compilation requests. For this reason, when JITServer AOT caching is enabled, the client JVM will attempt to generate as many AOT requests as possible.

--- a/docs/version0.36.md
+++ b/docs/version0.36.md
@@ -1,0 +1,50 @@
+<!--
+* Copyright (c) 2017, 2022 IBM Corp. and others
+*
+* This program and the accompanying materials are made
+* available under the terms of the Eclipse Public License 2.0
+* which accompanies this distribution and is available at
+* https://www.eclipse.org/legal/epl-2.0/ or the Apache
+* License, Version 2.0 which accompanies this distribution and
+* is available at https://www.apache.org/licenses/LICENSE-2.0.
+*
+* This Source Code may also be made available under the
+* following Secondary Licenses when the conditions for such
+* availability set forth in the Eclipse Public License, v. 2.0
+* are satisfied: GNU General Public License, version 2 with
+* the GNU Classpath Exception [1] and GNU General Public
+* License, version 2 with the OpenJDK Assembly Exception [2].
+*
+* [1] https://www.gnu.org/software/classpath/license.html
+* [2] http://openjdk.java.net/legal/assembly-exception.html
+*
+* SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH
+* Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+-->
+
+# What's new in version 0.36.0
+
+The following new features and notable changes since version 0.35.0 are included in this release:
+
+- [New binaries and changes to supported environments](#binaries-and-supported-environments)
+- [New `-XX:JITServerAOTmx` option added](#new-xxjitserveraotmx-option-added)
+
+## Features and changes
+
+### Binaries and supported environments
+
+Eclipse OpenJ9&trade; release 0.36.0 supports OpenJDK 8, 11, and 17.
+
+To learn more about support for OpenJ9 releases, including OpenJDK levels and platform support, see [Supported environments](openj9_support.md).
+
+### New `-XX:JITServerAOTmx` option added
+
+This option specifies the maximum amount of memory that can be used by the JITServer AOT cache. Instead of unlimited memory consumption, the maximum amount of memory that all AOT cache instances combined can use at the server is now limited to 300 MB, by default.
+
+For more information, see [`-XX:JITServerAOTmx`](xxjitserveraotmx.md).
+
+## Known problems and full release information
+
+To see known problems and a complete list of changes between Eclipse OpenJ9 v0.33.1 and v0.35.0 releases, see the [Release notes](https://github.com/eclipse-openj9/openj9/blob/master/doc/release-notes/0.35/0.35.md).
+
+<!-- ==== END OF TOPIC ==== version0.35.md ==== -->

--- a/docs/xxjitserveraotmx.md
+++ b/docs/xxjitserveraotmx.md
@@ -1,0 +1,49 @@
+<!--
+* Copyright (c) 2017, 2022 IBM Corp. and others
+*
+* This program and the accompanying materials are made
+* available under the terms of the Eclipse Public License 2.0
+* which accompanies this distribution and is available at
+* https://www.eclipse.org/legal/epl-2.0/ or the Apache
+* License, Version 2.0 which accompanies this distribution and
+* is available at https://www.apache.org/licenses/LICENSE-2.0.
+*
+* This Source Code may also be made available under the
+* following Secondary Licenses when the conditions for such
+* availability set forth in the Eclipse Public License, v. 2.0
+* are satisfied: GNU General Public License, version 2 with
+* the GNU Classpath Exception [1] and GNU General Public
+* License, version 2 with the OpenJDK Assembly Exception [2].
+*
+* [1] https://www.gnu.org/software/classpath/license.html
+* [2] http://openjdk.java.net/legal/assembly-exception.html
+*
+* SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH
+* Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+-->
+
+# -XX:JITServerAOTmx
+
+**(Linux&reg; only)**
+
+This option specifies the maximum amount of memory allocated to the JITServer AOT cache for storing the compiled code and for the associated data structures that are used in the cache's implementation.
+
+## Syntax
+
+        -XX:JITServerAOTmx=<size>
+
+| Setting                 | Effect | Default                                                                            |
+|-------------------------|--------|:----------------------------------------------------------------------------------:|
+| `-XX:JITServerAOTmx=<size>`    | Limits the amount of memory used by the JITServer AOT cache |  300 MB                       |
+
+## Explanation
+
+When the JITServer receives an AOT compilation request, it checks its AOT cache for a compatible compiled method body. If one is not found, the server performs the AOT compilation, sends the response to the client JVM, then stores the compiled method in its local AOT cache, for future use. Multiple requests and storing of the compiled methods can use a lot of memory and degrade the system's overall performance.
+
+You can specify the maximum memory limit for the AOT cache by using the `-XX:JITServerAOTmx=<size>` option, so that when the JITServer reaches that limit, it will not be able to add new AOT methods to its AOT cache. This will limit the amount of memory used for caching the compiled code and prevent memory shortages at JITServer that could lead to poor performance or even native out-of-memory events.
+
+## See also
+
+- [JITServer AOT cache](jitserver_tuning.md#jitserver-aot-cache)
+
+<!-- ==== END OF TOPIC ==== xxjitserveraotmx.md ==== -->

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -102,6 +102,7 @@ nav:
 
     - "Release notes" :
         - "Overview"                                                             : openj9_releases.md
+        - "Version 0.36.0"                                                       : version0.36.md
         - "Version 0.35.0"                                                       : version0.35.md
         - "Version 0.33.x"                                                       : version0.33.md
         - "Version 0.32.0"                                                       : version0.32.md
@@ -382,7 +383,7 @@ nav:
             - "-XX:[+|-]JITInlineWatches"                                        : xxjitinlinewatches.md
             - "-XX:JITServerAddress"                                             : xxjitserveraddress.md
             - "-XX:JITServerAOTCacheName"                                        : xxjitserveraotcachename.md
-            - "-XX:[+|-]JITServerUseAOTCache"                                    : xxjitserveruseaotcache.md
+            - "-XX:JITServerAOTmx"                                               : xxjitserveraotmx.md
             - "-XX:[+|-]JITServerLocalSyncCompiles"                              : xxjitserverlocalsynccompiles.md
             - "-XX:[+|-]JITServerLogConnections"                                 : xxjitserverlogconnections.md
             - "-XX:JITServerMetrics"                                             : xxjitservermetrics.md
@@ -395,6 +396,7 @@ nav:
             - "-XX:JITServerSSLKey"                                              : xxjitserversslcert.md        #redirect
             - "-XX:JITServerSSLRootCerts"                                        : xxjitserversslcert.md        #redirect
             - "-XX:JITServerTimeout"                                             : xxjitservertimeout.md
+            - "-XX:[+|-]JITServerUseAOTCache"                                    : xxjitserveruseaotcache.md
             - "-XX:[+|-]LazySymbolResolution"                                    : xxlazysymbolresolution.md
             - "-XX:[+|-]LegacyXLogOption"                                        : xxlegacyxlogoption.md
             - "-XX:MaxDirectMemorySize"                                          : xxmaxdirectmemorysize.md


### PR DESCRIPTION
https://github.com/eclipse-openj9/openj9-docs/issues/1004

Updated the related documents with the new -XX:JITServerAOTmx option information.

Signed-off-by: Sreekala Gopakumar <sreekala.gopakumar@ibm.com>