### PR TITLE
Document JITServer AOT cache persistence

### DIFF
--- a/docs/jitserver.md
+++ b/docs/jitserver.md
@@ -70,6 +70,8 @@ You can use command line options to further configure the JITServer and the clie
 - [`-XX:JITServerAOTCacheName=<cache_name>`](xxjitserveraotcachename.md): Specifies the name of the server-side AOT cache to use
 - [`-XX:[+|-]JITServerUseAOTCache`](xxjitserveruseaotcache.md): Specifies whether the server caches AOT-compiled methods
 - [`-XX:JITServerAOTmx=<size>`](xxjitserveraotmx.md): Specifies the maximum amount of memory that can be used by the JITServer AOT cache
+- [`-XX:[+|-]JITServerAOTCachePersistence`](xxjitserveraotcachepersistence.md): Specifies whether the JITServer server allows other JITServer instances to reuse AOT caches
+- [`-XX:JITServerAOTCacheDir=<directory>`](xxjitserveraotcachedir.md): Specifies the directory to be used for saving and loading JITServer AOT cache files
 
 If a JITServer server crashes, the client is forced to perform compilations locally. You can change this behavior by using the [`-XX:[+|-]RequireJITServer`](xxrequirejitserver.md) option so that the client crashes with an assert when it detects that the server is unavailable. This feature is useful when you are running a test suite with JITServer enabled and you want the server crash to cause the test to fail.
 

--- a/docs/version0.36.md
+++ b/docs/version0.36.md
@@ -31,6 +31,8 @@ The following new features and notable changes since version 0.35.0 are included
 - [Changes to the location of the default directory for the shared cache and snapshot](#changes-to-the-location-of-the-default-directory-for-the-shared-cache-and-snapshot)
 - [New `-XX:[+|-]MergeCompilerOptions` option added](#new-xx-mergecompileroptions-option-added)
 - [Default JITServer AOT cache name changed](#default-jitserver-aot-cache-name-changed)
+- [New `-XX:[+|-]JITServerAOTCachePersistence` option added](#new-xx-jitserveraotcachepersistence-option-added)
+- [New `-XX:JITServerAOTCacheDir` option added](#new-xxjitserveraotcachedir-option-added)
 
 ## Features and changes
 
@@ -82,7 +84,19 @@ A JITServer instance can have several AOT caches, each with its own name. Client
 
 This change is to allow AOT cache persistence, whereby JITServer can periodically save its AOT caches to files with names that include the name of the cache. JITServer can then load caches from such files when a client requests a particular cache.
 
-For more information, see [`-XX:JITServerAOTCacheName`](xxjitserveraotcachename.md) and `-XX:[+|-]JITServerAOTCachePersistence`.
+For more information, see [`-XX:JITServerAOTCacheName`](xxjitserveraotcachename.md) and [`-XX:[+|-]JITServerAOTCachePersistence`](xxjitserveraotcachepersistence.md).
+
+### New `-XX:[+|-]JITServerAOTCachePersistence` option added
+
+The AOT cache was a non-persistent in-memory cache. If the JITServer instance terminated, the cache content was lost. Now, with the `-XX:+JITServerAOTCachePersistence` option, the JITServer server periodically saves its AOT caches to files, and allows other JITServer instances to load these caches from files the first time a client requests a particular cache.
+
+For more information, see [`-XX:[+|-]JITServerAOTCachePersistence`](xxjitserveraotcachepersistence.md).
+
+### New `-XX:JITServerAOTCacheDir` option added
+
+You can specify the directory for saving or loading the AOT cache files with the `-XX:JITServerAOTCacheDir=<directory>` option. If the option is not used, AOT cache files are saved to (or loaded from) the current working directory of the JITServer server.
+
+For more information, see [`-XX:JITServerAOTCacheDir`](xxjitserveraotcachedir.md).
 
 ## Known problems and full release information
 

--- a/docs/xxjitserveraotcachedir.md
+++ b/docs/xxjitserveraotcachedir.md
@@ -1,0 +1,53 @@
+<!--
+* Copyright (c) 2017, 2022 IBM Corp. and others
+*
+* This program and the accompanying materials are made
+* available under the terms of the Eclipse Public License 2.0
+* which accompanies this distribution and is available at
+* https://www.eclipse.org/legal/epl-2.0/ or the Apache
+* License, Version 2.0 which accompanies this distribution and
+* is available at https://www.apache.org/licenses/LICENSE-2.0.
+*
+* This Source Code may also be made available under the
+* following Secondary Licenses when the conditions for such
+* availability set forth in the Eclipse Public License, v. 2.0
+* are satisfied: GNU General Public License, version 2 with
+* the GNU Classpath Exception [1] and GNU General Public
+* License, version 2 with the OpenJDK Assembly Exception [2].
+*
+* [1] https://www.gnu.org/software/classpath/license.html
+* [2] http://openjdk.java.net/legal/assembly-exception.html
+*
+* SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH
+* Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+-->
+
+# -XX:JITServerAOTCacheDir
+
+**(Linux&reg; only)**
+
+This option specifies the directory to be used for saving and loading JITServer AOT cache files.
+
+## Syntax
+
+        -XX:JITServerAOTCacheDir=<directory>
+
+ If the option is not specified, the cache files are saved in the current working directory of the JITServer server.
+
+## Explanation
+
+ A JITServer instance can have several AOT caches, each with its own name. To allow reusing of the AOT caches by other JITServer instances (such as the instances started later), you can use the [`-XX:+JITServerAOTCachePersistence`](xxjitserveraotcachepersistence.md) option. With this option enabled, JITServer server periodically saves its AOT caches to files, allowing its other instances to load caches from these files the first time a client requests a particular cache.
+
+ You can specify the directory for saving the AOT cache files with the `-XX:JITServerAOTCacheDir=<directory>` option. When the server receives the location of the requested AOT cache file through the `-XX:JITServerAOTCacheDir` option and a request for a specific cache name, if that cache does not exist in-memory, the server searches the specified cache directory for the file with the matching name and loads it, if available.
+
+ This option is not applicable if the JITServer AOT cache persistence feature is not enabled with the `-XX:+JITServerAOTCachePersistence` option.
+
+## See also
+
+- [JITServer AOT cache](jitserver_tuning.md#jitserver-aot-cache)
+- [`-XX:[+|-]JITServerUseAOTCache`](xxjitserveruseaotcache.md)
+- [`-XX:JITServerAOTCacheName`](xxjitserveraotcachename.md)
+- [`-XX:[+|-]JITServerAOTCachePersistence`](xxjitserveraotcachepersistence.md)
+
+
+<!-- ==== END OF TOPIC ==== xxjitserveraotcachedir.md ==== -->

--- a/docs/xxjitserveraotcachename.md
+++ b/docs/xxjitserveraotcachename.md
@@ -44,5 +44,7 @@
 
  - [JITServer technology](jitserver.md)
  - [`-XX:[+|-]JITServerUseAOTCache`](xxjitserveruseaotcache.md)
+ - [`-XX:JITServerAOTCacheDir`](xxjitserveraotcachedir.md)
+ - [`-XX:[+|-]JITServerAOTCachePersistence`](xxjitserveraotcachepersistence.md)
 
 <!-- ==== END OF TOPIC ==== xxjitserveraotcachename.md ==== -->

--- a/docs/xxjitserveraotcachepersistence.md
+++ b/docs/xxjitserveraotcachepersistence.md
@@ -1,0 +1,65 @@
+<!--
+* Copyright (c) 2017, 2022 IBM Corp. and others
+*
+* This program and the accompanying materials are made
+* available under the terms of the Eclipse Public License 2.0
+* which accompanies this distribution and is available at
+* https://www.eclipse.org/legal/epl-2.0/ or the Apache
+* License, Version 2.0 which accompanies this distribution and
+* is available at https://www.apache.org/licenses/LICENSE-2.0.
+*
+* This Source Code may also be made available under the
+* following Secondary Licenses when the conditions for such
+* availability set forth in the Eclipse Public License, v. 2.0
+* are satisfied: GNU General Public License, version 2 with
+* the GNU Classpath Exception [1] and GNU General Public
+* License, version 2 with the OpenJDK Assembly Exception [2].
+*
+* [1] https://www.gnu.org/software/classpath/license.html
+* [2] http://openjdk.java.net/legal/assembly-exception.html
+*
+* SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH
+* Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+-->
+
+# -XX:[+|-]JITServerAOTCachePersistence
+
+**(Linux&reg; only)**
+
+This option enables or disables the JITServer server's ability to allow other JITServer instances to reuse AOT caches.
+
+## Syntax
+
+        -XX:[+|-]JITServerAOTCachePersistence
+
+| Setting                    | Effect  | Default                                                                              |
+|----------------------------|---------|:------------------------------------------------------------------------------------:|
+|`-XX:+JITServerAOTCachePersistence` | Enable  |                                                                                      |
+|`-XX:-JITServerAOTCachePersistence` | Disable | :fontawesome-solid-check:{: .yes aria-hidden="true"}<span class="sr-only">yes</span> |
+
+## Explanation
+
+ With the `-XX:+JITServerAOTCachePersistence` option, the JITServer server periodically saves its AOT caches to files, allowing other JITServer instances to load these caches from files the first time a client requests a particular named cache. It is useful to improve performance, especially in scenarios where JITServer instances are started up and shut down regularly.
+
+ This feature depends on the [`-XX:+JITServerUseAOTCache`](xxjitserveruseaotcache.md) command-line option, which is used to enable caching of AOT-compiled methods. You must specify this option both at the client JVM and at the server.
+
+ Use the [`-XX:JITServerAOTCacheName=<cache_name>`](xxjitserveraotcachename) option at the client to request a particular AOT cache. If the requested cache does not exist at the server in-memory, but the AOT cache persistence feature is enabled (`-XX:+JITServerAOTCachePersistence`), the server checks whether a file for that cache exists. If the AOT cache file exists, it is loaded in the background. If the AOT cache file does not exist or the AOT cache persistence feature is disabled (`-XX:-JITServerAOTCachePersistence`), the server creates an empty AOT cache and gradually populates it with AOT method bodies it compiles.
+
+ You can use the [`-XX:JITServerAOTCacheDir=<directory>`](xxjitserveraotcachedir.md) option to specify the directory where the AOT cache must be saved to or loaded from.
+
+ The name of an AOT cache file has the following structure:
+
+        JITServerAOTCache.<CACHE_NAME>.J<JAVA_VERSION>
+ Where,
+
+ - `<CACHE_NAME>` is the name of the AOT cache requested by the client, and
+ - `<JAVA_VERSION>` is the version of Java used by JITServer instance (for example, 17 will be used for Java 17)
+
+## See also
+
+- [`-XX:JITServerAOTCacheName`](xxjitserveraotcachename.md)
+- [`-XX:JITServerAOTCacheDir`](xxjitserveraotcachedir.md)
+- [`-XX:[+|-]JITServerUseAOTCache`](xxjitserveruseaotcache.md)
+- [JITServer AOT cache](jitserver_tuning.md#jitserver-aot-cache)
+
+<!-- ==== END OF TOPIC ==== xxjitserveraotcachepersistence.md ==== -->

--- a/docs/xxjitserveruseaotcache.md
+++ b/docs/xxjitserveruseaotcache.md
@@ -50,5 +50,7 @@ The [`-XX:+JITServerShareROMClasses`](xxjitservershareromclasses.md) option is e
 
 - [JITServer technology](jitserver.md)
 - [`-XX:JITServerAOTCacheName`](xxjitserveraotcachename.md)
+- [`-XX:JITServerAOTCacheDir`](xxjitserveraotcachedir.md)
+- [`-XX:[+|-]JITServerAOTCachePersistence`](xxjitserveraotcachepersistence.md)
 
 <!-- ==== END OF TOPIC ==== xxjitserveruseaotcache.md ==== -->

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -382,7 +382,9 @@ nav:
             - "-XX:[+|-]InterleaveMemory"                                        : xxinterleavememory.md
             - "-XX:[+|-]JITInlineWatches"                                        : xxjitinlinewatches.md
             - "-XX:JITServerAddress"                                             : xxjitserveraddress.md
+            - "-XX:JITServerAOTCacheDir"                                         : xxjitserveraotcachedir.md
             - "-XX:JITServerAOTCacheName"                                        : xxjitserveraotcachename.md
+            - "-XX:[+|-]JITServerAOTCachePersistence"                            : xxjitserveraotcachepersistence.md
             - "-XX:JITServerAOTmx"                                               : xxjitserveraotmx.md
             - "-XX:[+|-]JITServerLocalSyncCompiles"                              : xxjitserverlocalsynccompiles.md
             - "-XX:[+|-]JITServerLogConnections"                                 : xxjitserverlogconnections.md


### PR DESCRIPTION
https://github.com/eclipse-openj9/openj9-docs/issues/1025

Added information about the new options

-XX:[+|-]JITServerAOTCachePersistence
-Xjit:aotCachePersistenceMinDeltaMethods
-Xjit:aotCachePersistenceMinPeriodMs
-XX:JITServerAOTCacheDir

Signed-off-by: Sreekala Gopakumar <sreekala.gopakumar@ibm.com>