### PR TITLE
Publish release docs to the docs branch

### DIFF
--- a/JenkinsFile_build_doc.groovy
+++ b/JenkinsFile_build_doc.groovy
@@ -157,25 +157,12 @@ timeout(time: 6, unit: 'HOURS') {
                             sh "tar -zcf ${ARCHIVE} site/"
                             stash includes: "${ARCHIVE}", name: 'doc'
 
-                            // Cleanup and rebuild the Doc for push to Github repo as a downlaodable zip.
-                            // Build, save zip file, cleanup and checkout master branch, bring back zip file and commit/push.
                             sh """
-                                git clean -ffxd
-                                git status
-                                sed -i "s|site_dir: 'site'|use_directory_urls: false\\nsite_dir: 'site'|" mkdocs.yml
-                                sed -i "/- search/d" mkdocs.yml
-                                mkdocs build -v
-                                cd site
-                                zip -r ${ZIP_FILENAME} *
-                                mv ${ZIP_FILENAME} ${WORKSPACE}/
-                                cd ..
                                 git clean -ffxd
                                 git reset --hard
                                 git status
                                 git checkout master
-                                mv ${WORKSPACE}/${ZIP_FILENAME} downloads/
                             """
-                            push_doc_with_cred(OPENJ9_REPO, 'master', "Add zip download of ${RELEASE_BRANCH} release user documentation")
                         }
                     }
                 } // Exit container


### PR DESCRIPTION
Related to https://gitlab.eclipse.org/eclipsefdn/helpdesk/-/issues/1849

Seems there are two websites, one for the main website and one for docs. Publish the docs to the docs branch rather than combine them with the main website.

Tested via https://openj9-jenkins.osuosl.org/view/Website-Doc/job/Build-Doc-Push_to_Eclipse/29/

The docs are published to https://github.com/eclipse-openj9/openj9-website-publish/tree/docs