### PR TITLE
Build jdk19+ Windows with VS 2022

### DIFF
--- a/docs/openj9_support.md
+++ b/docs/openj9_support.md
@@ -252,7 +252,7 @@ The project builds and tests OpenJDK with OpenJ9 on a number of platforms. The o
 | Linux on POWER LE 64-bit      | CentOS 7.9             | gcc 11.2                              |
 | Linux on IBM Z 64-bit         | RHEL 7.9               | gcc 11.2                              |
 | Linux AArch64 64-bit          | CentOS 7.9             | gcc 10.3                              |
-| Windows x86 64-bit            | Windows Server 2012 R2 | Microsoft Visual Studio 2019          |
+| Windows x86 64-bit            | Windows Server 2012 R2 | Microsoft Visual Studio 2022          |
 | macOS x86 64-bit              | macOS 10.15.7          | xcode 12.4 and clang 12.0.0           |
 | macOS AArch64                 | macOS 11.5.2           | xcode 13.0 and clang 13.0.0           |
 | AIX POWER BE 64-bit           | AIX 7.2 TL5            | xlc/C++ 16.1.0.11                     |

--- a/docs/version0.37.md
+++ b/docs/version0.37.md
@@ -40,6 +40,8 @@ RHEL 8.2 is out of support. RHEL 8.4 is the new minimum operating system level.
 
 Support for running OpenJDK 8 and OpenJDK 11 on CentOS 6.10 is deprecated and might be removed in a future release. OpenJ9 will not be tested with OpenJDK 11 on CentOS 6.10 for the 0.37.0 release.
 
+OpenJ9 Windows&reg; builds for OpenJDK 19 and later are now compiled with Microsoft&reg; Visual Studio 2022. The Visual Studio redistributable files included with the build are updated to match.
+
 To learn more about support for OpenJ9 releases, including OpenJDK levels and platform support, see [Supported environments](openj9_support.md).
 
 ### AIX is now built on AIX 7.2 TL5


### PR DESCRIPTION
Closes https://github.com/eclipse-openj9/openj9-docs/issues/1055

Updated the Visual Studio version used for compiling OpenJ9 Windows builds for OpenJDK 19 and later.

Signed-off-by: Sreekala Gopakumar <sreekala.gopakumar@ibm.com>