### PR TITLE
Add zOS default settings under -Xlp:objectheap pagesize

### DIFF
--- a/docs/xlpobjectheap.md
+++ b/docs/xlpobjectheap.md
@@ -61,6 +61,8 @@ See [Using -X command-line options](x_jvm_commands.md) for more information abou
 
 : On macOS, the default page size is 4 KB.
 
+: On z/OS systems, the default page size is 1 MB pageable large pages. For more information, see [`pageable`|`nonpageable`](#pageablenonpageable).
+
 ### `strict` | `warn`
 
         -Xlp:objectheap:strict


### PR DESCRIPTION
https://github.com/eclipse-openj9/openj9-docs/issues/1064

Updated the section with the default page setting for z/OS and added a cross reference to the pageable|nonpageable section for more information.

Signed-off-by: Sreekala Gopakumar <sreekala.gopakumar@ibm.com>