### PR TITLE
Modify build_doc to set git core.preloadIndex false

### DIFF
--- a/JenkinsFile_build_doc.groovy
+++ b/JenkinsFile_build_doc.groovy
@@ -130,6 +130,10 @@ timeout(time: 6, unit: 'HOURS') {
                     if ((params.BUILD_TYPE == "PR") || (params.BUILD_TYPE == "MERGE")) {
                         stage("Push Doc") {
                             dir('push_repo') {
+                                // avoid "fatal: unable to create threaded lstat" from git status
+                                sh """
+                                    git config --global core.preloadIndex false
+                                    """
                                 checkout changelog: false, poll: false,
                                     scm: [$class: 'GitSCM',
                                         branches: [[name: PUSH_BRANCH]],


### PR DESCRIPTION
Avoid `fatal: unable to create threaded lstat` from `git status`

Closes https://github.com/eclipse-openj9/openj9/issues/16914

Tested in https://openj9-jenkins.osuosl.org/job/Build-Doc-Push_to_ghpages/184/ and it worked.