### PR TITLE
Correct -XX:[+|-]HandleSIGABRT

### DIFF
--- a/docs/cmdline_migration.md
+++ b/docs/cmdline_migration.md
@@ -101,7 +101,7 @@ You can set the following options to make OpenJ9 behave in the same way as HotSp
 | ![Start of content that applies only to Java 8 (LTS)](cr/java8.png) [`-Djava.lang.string.substring.nocopy=true`](djavalangstringsubstringnocopy.md) |  Avoid String sharing by `String.substring()`. |
 | [`-Xnuma:none`](xnumanone.md)               | Disable non-uniform memory architecture (NUMA) awareness.       |
 | ![Start of content that applies only to Java 11+ (LTS)](cr/java11plus.png)[`-XX:+CompactStrings`](xxcompactstrings.md)| Enables `String` compression.                 |
-| [`-XX:[+-]HandleSIGABRT`](xxhandlesigabrt.md)    | Force handling of SIGABRT signals to be compatible with HotSpot. |
+| [`-XX:[+|-]HandleSIGABRT`](xxhandlesigabrt.md)    | Force handling of SIGABRT signals to be compatible with HotSpot. |
 
 
 ## Compatible environment variables

--- a/docs/openj9_signals.md
+++ b/docs/openj9_signals.md
@@ -70,7 +70,7 @@ Note that certain signals on VM threads cause OpenJ9 to shutdown. An application
 :fontawesome-solid-pencil:{: .note aria-hidden="true"} **Notes:**
 
 - The use of `SIGRTMIN` is configurable with the [`-Xdump:suspendwith=<num>`](xdump.md) option.
-- The handling of `SIGABRT` is configurable with the [`-XX:[+-]HandleSIGABRT`](xxhandlesigabrt.md) option.
+- The handling of `SIGABRT` is configurable with the [`-XX:[+|-]HandleSIGABRT`](xxhandlesigabrt.md) option.
 - The handling of `SIGUSR2` is configurable with the [`-XX:[+|-]HandleSIGUSR2`](xxhandlesigusr2.md) option.
 
 ## Signals on macOS
@@ -94,7 +94,7 @@ Note that certain signals on VM threads cause OpenJ9 to shutdown. An application
 
 :fontawesome-solid-pencil:{: .note aria-hidden="true"} **Note:**
 
-- The handling of `SIGABRT` is configurable with the [`-XX:[+-]HandleSIGABRT`](xxhandlesigabrt.md) option.
+- The handling of `SIGABRT` is configurable with the [`-XX:[+|-]HandleSIGABRT`](xxhandlesigabrt.md) option.
 - The handling of `SIGUSR2` is configurable with the [`-XX:[+|-]HandleSIGUSR2`](xxhandlesigusr2.md) option.
 
 ## Signals on Windows
@@ -135,7 +135,7 @@ All mechanisms can be disabled by using the `-Xrs` option. However, only structu
 
 :fontawesome-solid-pencil:{: .note aria-hidden="true"} **Note:**
 
-- The handling of `SIGABRT` is configurable with the [`-XX:[+-]HandleSIGABRT`](xxhandlesigabrt.md) option.
+- The handling of `SIGABRT` is configurable with the [`-XX:[+|-]HandleSIGABRT`](xxhandlesigabrt.md) option.
 - The handling of `SIGUSR2` is configurable with the [`-XX:[+|-]HandleSIGUSR2`](xxhandlesigusr2.md) option.
 
 ## Signals on AIX
@@ -163,7 +163,7 @@ All mechanisms can be disabled by using the `-Xrs` option. However, only structu
 
 - VM performance is affected if you install a signal handler for SIGTRAP (5) or SIGRECONFIG (58) because these signals are used for internal control purposes.
 - If you want to generate floating point exceptions, use the following call in your code to generate a `SIGFPE` signal: `fp_trap( P_TRAP_SYNC)`. Although you can use the C compiler `-qflttrap` setting to generate `SIGTRAP` signals to trap floating point exceptions, this mechanism can affect the JIT compiler.
-- The handling of `SIGABRT` is configurable with the [`-XX:[+-]HandleSIGABRT`](xxhandlesigabrt.md) option.
+- The handling of `SIGABRT` is configurable with the [`-XX:[+|-]HandleSIGABRT`](xxhandlesigabrt.md) option.
 - The handling of `SIGUSR2` is configurable with the [`-XX:[+|-]HandleSIGUSR2`](xxhandlesigusr2.md) option.
 
 ## Signal chaining


### PR DESCRIPTION
Added the missing pipe symbol.

Related: #1084