### PR TITLE
Update JenkinsFile_build_doc.groovy

### DIFF
--- a/JenkinsFile_build_doc.groovy
+++ b/JenkinsFile_build_doc.groovy
@@ -75,7 +75,7 @@ switch (params.BUILD_TYPE) {
 
 timeout(time: 6, unit: 'HOURS') {
     timestamps {
-        node('hw.arch.x86&&sw.tool.docker') {
+        node('hw.arch.x86&&sw.tool.docker&&sw.os.cent') {
             try {
                 def TMP_DESC = (currentBuild.description) ? currentBuild.description + "<br>" : ""
                 currentBuild.description = TMP_DESC + "<a href=${JENKINS_URL}computer/${NODE_NAME}>${NODE_NAME}</a>"


### PR DESCRIPTION
To correct the Jenkins doc stage build failure as suggested by Adam Brousseau. Reason for this change is that the Docker build only passes on cent machines and was failing on Ubuntu machines

Signed-off-by: Sreekala Gopakumar <sreekala.gopakumar@ibm.com>