### PR TITLE
Document new option -XX:codecachetotalMaxRAMPercentage

### DIFF
--- a/docs/version0.40.md
+++ b/docs/version0.40.md
@@ -1,0 +1,49 @@
+<!--
+* Copyright (c) 2017, 2023 IBM Corp. and others
+*
+* This program and the accompanying materials are made
+* available under the terms of the Eclipse Public License 2.0
+* which accompanies this distribution and is available at
+* https://www.eclipse.org/legal/epl-2.0/ or the Apache
+* License, Version 2.0 which accompanies this distribution and
+* is available at https://www.apache.org/licenses/LICENSE-2.0.
+*
+* This Source Code may also be made available under the
+* following Secondary Licenses when the conditions for such
+* availability set forth in the Eclipse Public License, v. 2.0
+* are satisfied: GNU General Public License, version 2 with
+* the GNU Classpath Exception [1] and GNU General Public
+* License, version 2 with the OpenJDK Assembly Exception [2].
+*
+* [1] https://www.gnu.org/software/classpath/license.html
+* [2] https://openjdk.org/legal/assembly-exception.html
+*
+* SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0 OR GPL-2.0-only WITH OpenJDK-assembly-exception-1.0
+-->
+
+# What's new in version 0.40.0
+
+The following new features and notable changes since version 0.39.0 are included in this release:
+
+- [New binaries and changes to supported environments](#binaries-and-supported-environments)
+- [New `-XX:codecachetotalMaxRAMPercentage` option added](#new-xxcodecachetotalmaxrampercentage-option-added)
+
+## Features and changes
+
+### Binaries and supported environments
+
+Eclipse OpenJ9&trade; release 0.40.0 supports OpenJDK 8, 11, 17, and 20.
+
+To learn more about support for OpenJ9 releases, including OpenJDK levels and platform support, see [Supported environments](openj9_support.md).
+
+### New `-XX:codecachetotalMaxRAMPercentage` option added
+
+In environments with low physical memory availability, the VM might use too much memory for JIT code caches, leaving little memory for critical operations. With the `-XX:codecachetotalMaxRAMPercentage` option, you can set an upper limit for the total code cache size, where the upper limit is specified as a percentage of the physical memory the VM process is allowed to use.
+
+For more information, see [`-XX:codecachetotalMaxRAMPercentage`](xxcodecachetotalmaxrampercentage.md).
+
+## Known problems and full release information
+
+To see known problems and a complete list of changes between Eclipse OpenJ9 v0.39.0 and v0.40.0 releases, see the [Release notes](https://github.com/eclipse-openj9/openj9/blob/master/doc/release-notes/0.40/0.40.md).
+
+<!-- ==== END OF TOPIC ==== version0.40.md ==== -->

--- a/docs/xcodecachetotal.md
+++ b/docs/xcodecachetotal.md
@@ -36,7 +36,7 @@ See [Using -X command-line options](x_jvm_commands.md) for more information abou
 
 ## Explanation
 
-By default, the total size of the JIT code cache is 256 MB for a 64-bit VM and 64 MB for a 31/32-bit VM. Long-running, complex, server-type applications can fill the JIT code cache, which can cause performance problems because not all of the important methods can be JIT-compiled. Use the `-Xcodecachetotal` option to increase or decrease the maximum code cache size to a setting that suits your application. The minimum size of the code cache is restricted to 2 MB.
+By default, the total JIT code cache size is 256 MB for a 64-bit VM and 64 MB for a 31/32-bit VM or 25% of the physical memory available to the VM process, whichever is lesser. Long-running, complex, server-type applications can fill the JIT code cache, which can cause performance problems because not all of the important methods can be JIT-compiled. Use the `-Xcodecachetotal` option to increase or decrease the maximum code cache size to a setting that suits your application. The minimum size of the code cache is restricted to 2 MB.
 
 The value that you specify is rounded up to a multiple of the code cache block size, as specified by the [-Xcodecache](xcodecache.md) option. If you specify a value for the `-Xcodecachetotal` option that is smaller than the default setting, that value is ignored.
 
@@ -46,6 +46,7 @@ The maximum size limits, for both the JIT code and data caches, that are in use 
 
 ## See also
 
+- [`-XX:codecachetotalMaxRAMPercentage`](xxcodecachetotalmaxrampercentage.md)
 - [-Xjit](xjit.md)
 
 

--- a/docs/xxcodecachetotal.md
+++ b/docs/xxcodecachetotal.md
@@ -31,6 +31,8 @@ This option is an alias for the [`-Xcodecachetotal`](xcodecachetotal.md) option.
 
 : See [Using -X command-line options](x_jvm_commands.md) for more information about specifying the `<size>` parameter.
 
+## See also
 
+- [`-XX:codecachetotalMaxRAMPercentage`](xxcodecachetotalmaxrampercentage.md)
 
 <!-- ==== END OF TOPIC ==== xxcodecachetotal.md ==== -->

--- a/docs/xxcodecachetotalmaxrampercentage.md
+++ b/docs/xxcodecachetotalmaxrampercentage.md
@@ -1,0 +1,61 @@
+<!--
+* Copyright (c) 2017, 2022 IBM Corp. and others
+*
+* This program and the accompanying materials are made
+* available under the terms of the Eclipse Public License 2.0
+* which accompanies this distribution and is available at
+* https://www.eclipse.org/legal/epl-2.0/ or the Apache
+* License, Version 2.0 which accompanies this distribution and
+* is available at https://www.apache.org/licenses/LICENSE-2.0.
+*
+* This Source Code may also be made available under the
+* following Secondary Licenses when the conditions for such
+* availability set forth in the Eclipse Public License, v. 2.0
+* are satisfied: GNU General Public License, version 2 with
+* the GNU Classpath Exception [1] and GNU General Public
+* License, version 2 with the OpenJDK Assembly Exception [2].
+*
+* [1] https://www.gnu.org/software/classpath/license.html
+* [2] http://openjdk.java.net/legal/assembly-exception.html
+*
+* SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0 OR GPL-2.0-only WITH OpenJDK-assembly-exception-1.0
+-->
+
+# -XX:codecachetotalMaxRAMPercentage
+
+This option sets the maximum limit for the total JIT code cache size based on the amount of physical memory available to the VM.
+
+## Syntax
+
+        -XX:codecachetotalMaxRAMPercentage=<number>
+
+| Setting                 | Value      | Default                     |
+|-------------------------|------------|:---------------------------:|
+| `<number>`    | Between 1 and 100 (fractional numbers are allowed) |  25                       |
+
+Where `<number>` is the maximum limit that is expressed as a percentage of the available physical memory.
+
+For example, if you specify `-XX:codecachetotalMaxRAMPercentage=30`, the VM is not allowed to use more than 30% of the available physical memory for the internal JIT code caches.
+
+## Explanation
+
+The default total size of the JIT code cache is computed as the minimum of the following two limits:
+
+- A platform-based limit that is expressed as an absolute memory value. This limit is set at 256 MB for 64-bit systems and at 64 MB for 31/32-bit systems.
+- A percentage of the amount of available physical memory the VM process is allowed to use. By default, the VM is not allowed to use more than 25% of the available physical memory for its code caches.
+
+In memory constrained environments, the percentage limit is relevant because the code cache size is then based on the available physical memory. The percentage limit prevents the VM from using too much memory for its code caches and thus, leaving too little memory for other VM or JIT data structures.
+
+For example, on a 64-bit system, the platform-specific code cache limit is 256 MB. If the VM is constrained to less than 1024 MB, say 512 MB, then the code cache limit becomes 128 MB (25% of 512 MB) because the percentage limit is less than the platform limit.
+
+To fine-tune the code cache size limit for your specific application as a percentage of the available physical memory, you can use the `-XX:codecachetotalMaxRAMPercentage` option.
+
+As an alternative, you can use the [`-XX:codecachetotal`](xxcodecachetotal.md) or the [`-Xcodecachetotal`](xcodecachetotal.md) options to set the code cache size limit as an absolute value (platform-based limit). The absolute value that is specified with these options takes precedence over the percentage that is specified with the `-XX:codecachetotalMaxRAMPercentage` option.
+
+:fontawesome-solid-triangle-exclamation:{: .warn aria-hidden="true"} **Restrictions:**
+
+- If the `-XX:codecachetotal` or `-Xcodecachetotal` option is specified, then the `-XX:codecachetotalMaxRAMPercentage` option is ignored.
+- The percentage of the available physical memory that is specified in the `-XX:codecachetotalMaxRAMPercentage` option is used only if the total cache value thus calculated is less than the default total code cache value set for the platform (minimum of the two limits).
+
+
+<!-- ==== END OF TOPIC ==== xxcodecachetotalmaxrampercentage.md ==== -->

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -101,6 +101,7 @@ nav:
 
     - "Release notes" :
         - "Overview"                                                             : openj9_releases.md
+        - "Version 0.40.0"                                                       : version0.40.md
         - "Version 0.39.0"                                                       : version0.39.md
         - "Version 0.38.0"                                                       : version0.38.md
         - "Version 0.37.0"                                                       : version0.37.md
@@ -374,6 +375,7 @@ nav:
             - "-XX:[+|-]ClassRelationshipVerifier"                               : xxclassrelationshipverifier.md
             - "-XX:ConcGCThreads"                                                : xxconcgcthreads.md
             - "-XX:codecachetotal"                                               : xxcodecachetotal.md
+            - "-XX:codecachetotalMaxRAMPercentage"                               : xxcodecachetotalmaxrampercentage.md
             - "-XX:[+|-]CompactStrings"                                          : xxcompactstrings.md
             - "-XX:DiagnoseSyncOnValueBasedClasses"                              : xxdiagnosesynconvaluebasedclasses.md
             - "-XX:[+|-]DisableExplicitGC"                                       : xxdisableexplicitgc.md


### PR DESCRIPTION
https://github.com/eclipse-openj9/openj9-docs/issues/1108

Created new topic for the new option and updated other related topics including the What's new in version 0.40.0 topic.

Closes #1108
Signed-off-by: Sreekala Gopakumar <sreekala.gopakumar@ibm.com>