### PR TITLE
Remove Windows Server 2012 from supported platforms

### DIFF
--- a/docs/openj9_support.md
+++ b/docs/openj9_support.md
@@ -93,7 +93,6 @@ OpenJDK 8 binaries are expected to function on the minimum operating system leve
 |-------------------------------------------|--------------------------------------------------------------------------------------|--------------------------------------------------------------------------------------|
 | Windows 10                                | :fontawesome-solid-check:{: .yes aria-hidden="true"}<span class="sr-only">yes</span> | :fontawesome-solid-check:{: .yes aria-hidden="true"}<span class="sr-only">yes</span> |
 | Windows 11                                | :fontawesome-solid-check:{: .yes aria-hidden="true"}<span class="sr-only">yes</span> | :fontawesome-solid-check:{: .yes aria-hidden="true"}<span class="sr-only">yes</span> |
-| Windows Server 2012 R2                    | :fontawesome-solid-check:{: .yes aria-hidden="true"}<span class="sr-only">yes</span> | :fontawesome-solid-check:{: .yes aria-hidden="true"}<span class="sr-only">yes</span> |
 | Windows Server 2016                       | :fontawesome-solid-check:{: .yes aria-hidden="true"}<span class="sr-only">yes</span> | :fontawesome-solid-check:{: .yes aria-hidden="true"}<span class="sr-only">yes</span> |
 | Windows Server 2019                       | :fontawesome-solid-check:{: .yes aria-hidden="true"}<span class="sr-only">yes</span> | :fontawesome-solid-check:{: .yes aria-hidden="true"}<span class="sr-only">yes</span> |
 | Windows Server 2022                       | :fontawesome-solid-check:{: .yes aria-hidden="true"}<span class="sr-only">yes</span> | :fontawesome-solid-check:{: .yes aria-hidden="true"}<span class="sr-only">yes</span> |
@@ -140,7 +139,6 @@ OpenJDK 11 binaries are expected to function on the minimum operating system lev
 |-------------------------------------------|--------------------------------------------------------------------------------------|
 | Windows 10                                | :fontawesome-solid-check:{: .yes aria-hidden="true"}<span class="sr-only">yes</span> |
 | Windows 11                                | :fontawesome-solid-check:{: .yes aria-hidden="true"}<span class="sr-only">yes</span> |
-| Windows Server 2012 R2                    | :fontawesome-solid-check:{: .yes aria-hidden="true"}<span class="sr-only">yes</span> |
 | Windows Server 2016                       | :fontawesome-solid-check:{: .yes aria-hidden="true"}<span class="sr-only">yes</span> |
 | Windows Server 2019                       | :fontawesome-solid-check:{: .yes aria-hidden="true"}<span class="sr-only">yes</span> |
 | Windows Server 2022                       | :fontawesome-solid-check:{: .yes aria-hidden="true"}<span class="sr-only">yes</span> |
@@ -185,7 +183,6 @@ OpenJDK 17 binaries are expected to function on the minimum operating system lev
 |-------------------------------------------|--------------------------------------------------------------------------------------|
 | Windows 10                                | :fontawesome-solid-check:{: .yes aria-hidden="true"}<span class="sr-only">yes</span> |
 | Windows 11                                | :fontawesome-solid-check:{: .yes aria-hidden="true"}<span class="sr-only">yes</span> |
-| Windows Server 2012 R2                    | :fontawesome-solid-check:{: .yes aria-hidden="true"}<span class="sr-only">yes</span> |
 | Windows Server 2016                       | :fontawesome-solid-check:{: .yes aria-hidden="true"}<span class="sr-only">yes</span> |
 | Windows Server 2019                       | :fontawesome-solid-check:{: .yes aria-hidden="true"}<span class="sr-only">yes</span> |
 | Windows Server 2022                       | :fontawesome-solid-check:{: .yes aria-hidden="true"}<span class="sr-only">yes</span> |
@@ -204,9 +201,9 @@ OpenJDK 17 binaries are expected to function on the minimum operating system lev
 
 When public support for an operating system version ends, OpenJ9 can no longer be supported on that level.
 
-### OpenJDK 20
+### OpenJDK 21
 
-OpenJDK 20 binaries are expected to function on the minimum operating system levels shown in the following tables:
+OpenJDK 21 binaries are expected to function on the minimum operating system levels shown in the following tables:
 
 
 | Linux (**Note 1**)                        | AArch64                                                                              | x64                                                                                  | ppc64le                                                                              | Z64                                                                                  |
@@ -229,7 +226,6 @@ OpenJDK 20 binaries are expected to function on the minimum operating system lev
 |-------------------------------------------|--------------------------------------------------------------------------------------|
 | Windows 10                                | :fontawesome-solid-check:{: .yes aria-hidden="true"}<span class="sr-only">yes</span> |
 | Windows 11                                | :fontawesome-solid-check:{: .yes aria-hidden="true"}<span class="sr-only">yes</span> |
-| Windows Server 2012 R2                    | :fontawesome-solid-check:{: .yes aria-hidden="true"}<span class="sr-only">yes</span> |
 | Windows Server 2016                       | :fontawesome-solid-check:{: .yes aria-hidden="true"}<span class="sr-only">yes</span> |
 | Windows Server 2019                       | :fontawesome-solid-check:{: .yes aria-hidden="true"}<span class="sr-only">yes</span> |
 | Windows Server 2022                       | :fontawesome-solid-check:{: .yes aria-hidden="true"}<span class="sr-only">yes</span> |
@@ -259,8 +255,8 @@ The project builds and tests OpenJDK with OpenJ9 on a number of platforms. The o
 | Linux on POWER&reg; LE 64-bit | CentOS 7.9             | gcc 7.5                               |
 | Linux on IBM Z&reg; 64-bit    | RHEL 7.9               | gcc 7.5                               |
 | Linux AArch64 64-bit          | CentOS 7.9             | gcc 7.5                               |
-| Windows x86 32-bit            | Windows Server 2012 R2 | Microsoft Visual Studio 2019          |
-| Windows x86 64-bit            | Windows Server 2012 R2 | Microsoft Visual Studio 2019          |
+| Windows x86 32-bit            | Windows Server 2019    | Microsoft Visual Studio 2019          |
+| Windows x86 64-bit            | Windows Server 2019    | Microsoft Visual Studio 2019          |
 | macOS x86 64-bit              | OSX 10.15.7            | xcode 12.4 and clang 12.0.0           |
 | AIX POWER BE 64-bit           | AIX 7.2 TL5            | xlc/C++ 13.1.3                        |
 
@@ -272,7 +268,7 @@ The project builds and tests OpenJDK with OpenJ9 on a number of platforms. The o
 | Linux on POWER LE 64-bit      | CentOS 7.9             | gcc 7.5                               |
 | Linux on IBM Z 64-bit         | RHEL 7.9               | gcc 7.5                               |
 | Linux AArch64 64-bit          | CentOS 7.9             | gcc 7.5                               |
-| Windows x86 64-bit            | Windows Server 2012 R2 | Microsoft Visual Studio 2019          |
+| Windows x86 64-bit            | Windows Server 2019    | Microsoft Visual Studio 2019          |
 | macOS x86 64-bit              | macOS 10.15.7          | xcode 12.4 and clang 12.0.0           |
 | macOS AArch64                 | macOS 11.5.2           | xcode 13.0 and clang 13.0.0           |
 | AIX POWER BE 64-bit           | AIX 7.2 TL5            | xlc/C++ 16.1.0.11                     |
@@ -285,12 +281,12 @@ The project builds and tests OpenJDK with OpenJ9 on a number of platforms. The o
 | Linux on POWER LE 64-bit      | CentOS 7.9             | gcc 10.3                              |
 | Linux on IBM Z 64-bit         | RHEL 7.9               | gcc 10.3                              |
 | Linux AArch64 64-bit          | CentOS 7.9             | gcc 10.3                              |
-| Windows x86 64-bit            | Windows Server 2012 R2 | Microsoft Visual Studio 2019          |
+| Windows x86 64-bit            | Windows Server 2019    | Microsoft Visual Studio 2019          |
 | macOS x86 64-bit              | macOS 10.15.7          | xcode 12.4 and clang 12.0.0           |
 | macOS AArch64                 | macOS 11.5.2           | xcode 13.0 and clang 13.0.0           |
 | AIX POWER BE 64-bit           | AIX 7.2 TL5            | xlc/C++ 16.1.0.11                     |
 
-### OpenJDK 20 and later
+### OpenJDK 21 and later
 
 | Platform                      | Operating system       | Compiler                              |
 |-------------------------------|------------------------|---------------------------------------|
@@ -298,7 +294,7 @@ The project builds and tests OpenJDK with OpenJ9 on a number of platforms. The o
 | Linux on POWER LE 64-bit      | CentOS 7.9             | gcc 11.2                              |
 | Linux on IBM Z 64-bit         | RHEL 7.9               | gcc 11.2                              |
 | Linux AArch64 64-bit          | CentOS 7.9             | gcc 10.3                              |
-| Windows x86 64-bit            | Windows Server 2012 R2 | Microsoft Visual Studio 2022          |
+| Windows x86 64-bit            | Windows Server 2019    | Microsoft Visual Studio 2022          |
 | macOS x86 64-bit              | macOS 10.15.7          | xcode 12.4 and clang 12.0.0           |
 | macOS AArch64                 | macOS 11.5.2           | xcode 13.0 and clang 13.0.0           |
 | AIX POWER BE 64-bit           | AIX 7.2 TL5            | xlc/C++ 16.1.0.11                     |


### PR DESCRIPTION
Windows Server 2012 is out of support Oct 10, 2023
Closes https://github.com/eclipse-openj9/openj9-docs/issues/1149

Also change lists from "OpenjDK 20" to "OpenJDK 21" since 20 is out of support.