### PR TITLE
Changes to the behaviour of -Xshareclasses:readonly

### DIFF
--- a/docs/jitserver_tuning.md
+++ b/docs/jitserver_tuning.md
@@ -50,6 +50,8 @@ The client-session caches are deleted when the clients terminate, but this can h
  - The number of extra AOT methods added to the in-memory cache since the last save operation is equal to or more than the value specified by the `-Xjit:aotCachePersistenceMinDeltaMethods=<number_of_methods>` option (default value - 200 methods), and
  - The time passed since the last AOT cache save is equal to or later than the time specified by the `-Xjit:aotCachePersistenceMinPeriodMs=<milliseconds>` option (default time gap - 10000 milliseconds).
 
+ If the JITServer AOT cache feature and the [`-Xshareclasses:readonly`](xshareclasses.md#readonly) option are both enabled at the same time at a JITServer client, the shared class cache startup creates a temporary new (writable) top layer that the JITServer AOT cache can use to store data that it needs to function.
+
  Current limitation:
 
  - Caching works only for AOT compilation requests. For this reason, when JITServer AOT caching is enabled, the client JVM will attempt to generate as many AOT requests as possible.

--- a/docs/version0.41.md
+++ b/docs/version0.41.md
@@ -28,6 +28,7 @@ The following new features and notable changes since version 0.40.0 are included
 - [New binaries and changes to supported environments](#binaries-and-supported-environments)
 - ![Start of content that applies to Java 21 (LTS) and later](cr/java21plus.png) [New `-XX:[+|-]ShowCarrierFrames` option added](#new-xx-showcarrierframes-option-added) ![End of content that applies to Java 21 (LTS) and later](cr/java_close_lts.png)
 - ![Start of content that applies only to Java 11+ (LTS)](cr/java11plus.png) [`-XX:+CompactStrings` option enabled by default](#-xxcompactstrings-option-enabled-by-default) ![End of content that applies only to Java 11 and later](cr/java_close_lts.png)
+- [Change in behavior of `-Xshareclasses:readonly`](#change-in-behavior-of-xshareclassesreadonly)
 
 ## Features and changes
 
@@ -45,9 +46,15 @@ For more information, see [`-XX:[+|-]ShowCarrierFrames`](xxshowcarrierframes.md)
 
 ### ![Start of content that applies only to Java 11+ (LTS)](cr/java11plus.png) `-XX:+CompactStrings` option enabled by default
 
-Like HotSpot, the`-XX:+CompactStrings` option is now enabled by default on Java 11 and later. In the earlier versions, this option is disabled by default.
+Like HotSpot, the`-XX:+CompactStrings` option is now enabled by default on Java&trade; 11 and later. In the earlier versions, this option is disabled by default.
 
 For more information, see [`-XX:[+|-]CompactStrings`](xxcompactstrings.md). ![End of content that applies only to Java 11 and later](cr/java_close_lts.png)
+
+### Change in behavior of `-Xshareclasses:readonly`
+
+In the earlier releases, if the `-Xshareclasses:readonly` option and the JITServer AOT cache feature were both enabled at the same time at a JITServer client, the client could not use the JITServer AOT cache because the cache for storing data that the JITServer AOT cache needed was read-only.
+
+Now, with the change in behavior of the [`-Xshareclasses:readonly`](xshareclasses.md#readonly) option, the shared class cache startup creates a temporary new (writable) top layer that the JITServer AOT cache can use to store data that it needs to function.
 
 ## Known problems and full release information
 

--- a/docs/xshareclasses.md
+++ b/docs/xshareclasses.md
@@ -90,7 +90,7 @@ When you specify `-Xshareclasses` without any parameters and without specifying 
 
         -Xshareclasses:cacheDir=<directory>
 
-: Sets the directory in which cache data is read and written. Please do not set the cache directory on an NFS mount or a shared mount across systems or LPARs. The following defaults apply:
+: Sets the directory in which cache data is read and written. Do not set the cache directory on an NFS mount or a shared mount across systems or LPARs. The following defaults apply:
 
     - On Windows&trade; systems, `<directory>` is the user's `C:\Users\<username>\AppData\Local\javasharedresources` directory.
     - On z/OS&reg; systems, `<directory>` is the `/tmp/javasharedresources` directory.
@@ -491,6 +491,16 @@ behavior, which can improve the performance of class loading from the shared cla
 : On AIX, Linux, and macOS systems, this access is permitted only if the cache was created by using the [`-Xshareclasses:cacheDir`](#cachedir) option to specify a directory with appropriate permissions. If you do not use the `-Xshareclasses:cacheDir` option, the cache is created with default permissions, which do not permit access by other users or groups.
 
 : By default, this suboption is not specified.
+
+: The `-Xshareclasses:readonly` option is ignored under the following conditions:
+
+: - The JITServer AOT cache feature is enabled ([`-XX:+JITServerUseAOTCache`](xxjitserveruseaotcache.md)), and the VM is a client.
+ - The VM is running in a container.
+ - AOT compilation is enabled.<br>
+For more information about AOT compilation, see the [Ahead-Of-Time (AOT) compiler](aot.md) topic.
+ - The shared class cache is persistent. ([`-Xshareclasses:persistent`](xshareclasses.md#persistent))
+
+: If a persistent shared class cache is started under the mentioned conditions, the cache startup creates a temporary new (writable) top layer. The JITServer AOT cache uses the new top layer to store a small amount of metadata that the cache needs to function. With this top layer, the JITServer AOT cache can be used without modifying the existing layers.
 
 ### `reset`
 


### PR DESCRIPTION
https://github.com/eclipse-openj9/openj9-docs/issues/1145

Updated the -Xshareclasses:readonly topic and the JITServer AOT cache section in the JITServer tuning and practical considerations. Updated the What's new in version 0.42.0 topic.

Closes #1145
Signed-off-by: Sreekala Gopakumar <sreekala.gopakumar@ibm.com>