### PR TITLE
Control loading of the zlibNX library on AIX with -XX:[+|-]UseZlibNX

### DIFF
--- a/docs/version0.41.md
+++ b/docs/version0.41.md
@@ -31,6 +31,7 @@ The following new features and notable changes since version 0.40.0 are included
 - ![Start of content that applies only to Java 11+ (LTS)](cr/java11plus.png) [`-XX:+CompactStrings` option enabled by default](#-xxcompactstrings-option-enabled-by-default) ![End of content that applies only to Java 11 and later](cr/java_close_lts.png)
 - [Change in behavior of `-Xshareclasses:readonly`](#change-in-behavior-of-xshareclassesreadonly)
 - [New `-XX:[+|-]EnableDynamicAgentLoading` option added](#new-xx-enabledynamicagentloading-option-added)
+- [New `-XX:[+|-]UseZlibNX` option added](#new-xx-usezlibnx-option-added)
 
 ## Features and changes
 
@@ -71,6 +72,10 @@ This option enables or disables the dynamic loading of agents into a running VM.
 ![Start of content that applies to Java 21 (LTS) and later](cr/java21plus.png) For Java 21 and later, warnings are issued when the agents are loaded dynamically into a running VM after startup without specifying the `-XX:+EnableDynamicAgentLoading` option and the same agents were not loaded before. ![End of content that applies to Java 21 (LTS) and later](cr/java_close_lts.png)
 
 For more information, see [`-XX:[+|-]EnableDynamicAgentLoading`](xxenabledynamicagentloading.md).
+
+### New `-XX:[+|-]UseZlibNX` option added
+
+AIX&reg; system adds the `zlibnx` library directory path in the `LIBPATH` environment variable by default, if it is available in the system. You can control the loading of the `zlibnx` library by using the [`-XX:[+|-]UseZlibNX`](xxusezlibnx.md) option.
 
 ## Known problems and full release information
 

--- a/docs/xxusezlibnx.md
+++ b/docs/xxusezlibnx.md
@@ -1,0 +1,52 @@
+<!--
+* Copyright (c) 2017, 2023 IBM Corp. and others
+*
+* This program and the accompanying materials are made
+* available under the terms of the Eclipse Public License 2.0
+* which accompanies this distribution and is available at
+* https://www.eclipse.org/legal/epl-2.0/ or the Apache
+* License, Version 2.0 which accompanies this distribution and
+* is available at https://www.apache.org/licenses/LICENSE-2.0.
+*
+* This Source Code may also be made available under the
+* following Secondary Licenses when the conditions for such
+* availability set forth in the Eclipse Public License, v. 2.0
+* are satisfied: GNU General Public License, version 2 with
+* the GNU Classpath Exception [1] and GNU General Public
+* License, version 2 with the OpenJDK Assembly Exception [2].
+*
+* [1] https://www.gnu.org/software/classpath/license.html
+* [2] https://openjdk.org/legal/assembly-exception.html
+*
+* SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0 OR GPL-2.0-only WITH OpenJDK-assembly-exception-1.0
+-->
+
+# -XX:\[+|-\]UseZlibNX
+
+**AIX&reg; with IBM POWER9&reg; and later only**
+
+This option enables or disables the adding of the `zlibNX` library directory location to the `LIBPATH` environment variable.
+
+
+## Syntax
+
+        -XX:[+|-]UseZlibNX
+
+| Setting               | Effect  | Default                                                                            |
+|-----------------------|---------|:----------------------------------------------------------------------------------:|
+| `-XX:+UseZlibNX` |  Enable  |  :fontawesome-solid-check:{: .yes aria-hidden="true"}<span class="sr-only">yes</span>         |
+| `-XX:-UseZlibNX` | Disable |     |
+
+
+## Explanation
+
+AIX system adds the `zlibNX` library location, if available, to the `LIBPATH` variable by default. But having the `zlibNX` library directory location in the `LIBPATH` variable might cause some issues. For example, Git clone fails when executed from Java&reg; when `zlibNX` is on the `LIBPATH` in the environment.
+
+You can disable adding of the `zlibNX` library location to the `LIBPATH` variable with the `-XX:-UseZlibNX` option.
+
+## See also
+
+- [Hardware acceleration](introduction.md#hardware-acceleration)
+- [Configuring your system](configuring.md)
+
+<!-- ==== END OF TOPIC ==== xxusezlibnx.md ==== -->

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -465,6 +465,7 @@ nav:
             - "-XX:[+|-]UseGCStartupHints"                                       : xxusegcstartuphints.md
             - "-XX:[+|-]UseJITServer"                                            : xxusejitserver.md
             - "-XX:[+|-]UseNoGC"                                                 : xxusenogc.md
+            - "-XX:[+|-]UseZlibNX"                                               : xxusezlibnx.md
             - "-XX:[+|-]UTFCache"                                                : xxutfcache.md
             - "-XX:[+|-]VerboseVerification"                                     : xxverboseverification.md
             - "-XX:[+|-]VMLockClassLoader"                                       : xxvmlockclassloader.md


### PR DESCRIPTION
https://github.com/eclipse-openj9/openj9-docs/issues/1178

Created a new topic for -XX:[+|-]UseZlibNX. Updated the What's new in version 0.41.0

Closes #1178
Signed-off-by: Sreekala Gopakumar <sreekala.gopakumar@ibm.com>