### PR TITLE
Material emoji logic has been officially moved

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -88,8 +88,8 @@ markdown_extensions:
   - sane_lists
   - attr_list
   - pymdownx.emoji:   # enable icons in markdown
-      emoji_index: !!python/name:materialx.emoji.twemoji
-      emoji_generator: !!python/name:materialx.emoji.to_svg
+      emoji_index: !!python/name:material.extensions.emoji.twemoji
+      emoji_generator: !!python/name:material.extensions.emoji.to_svg
 
 
 nav:


### PR DESCRIPTION
Changes made in the yaml file to use Material's 'material.extensions.emoji.twemoji' and `material.extensions.emoji.to_svg` instead of `materialx.emoji.twemoji` and `materialx.emoji.to_svg`

Signed-off-by: Sreekala Gopakumar <sreekala.gopakumar@ibm.com>