### PR TITLE
Add support for threadAllocatedBytes MXBean API

### DIFF
--- a/docs/version0.41.md
+++ b/docs/version0.41.md
@@ -34,6 +34,7 @@ The following new features and notable changes since version 0.40.0 are included
 - [New `-XX:[+|-]UseZlibNX` option added](#new-xx-usezlibnx-option-added)
 - [Support for OpenSSL 3.x](#support-for-openssl-3x)
 - [Performance improvement](#performance-improvement)
+- [Support added for the `getThreadAllocatedBytes MXBean` API](#support-added-for-the-getthreadallocatedbytes-mxbean-api)
 
 ## Features and changes
 
@@ -86,6 +87,12 @@ OpenSSL 3.x is now supported on all operating systems. For more information abou
 ### Performance improvement
 
 Performance of algorithms with the use of OpenSSL version 3 and later is now enhanced. Improved algorithms include SHA256, AES, HmacSHA256, and ChaCha20. To obtain these improved algorithms and further enhance the performance of these algorithms on Linux&reg; and AIX, use OpenSSL 3.0.12 or a later 3.0.x version, or 3.1.4 or a later 3.1.x version.
+
+### Support added for the `getThreadAllocatedBytes MXBean` API
+
+With this release, the OpenJ9 VM implementation supports thread memory allocation measurement (`getThreadAllocatedBytes com.sun.management.ThreadMXBean` API). The `isThreadAllocatedMemorySupported` method now returns true. The `setThreadAllocatedMemoryEnabled()` and `isThreadAllocatedMemoryEnabled()` methods are also supported now.
+
+Support for the `getThreadAllocatedBytes MXBean` API is not added on z/OS&reg; platforms in this release.
 
 ## Known problems and full release information
 


### PR DESCRIPTION
https://github.com/eclipse-openj9/openj9-docs/issues/1199

Added the information related to threadAllocatedBytes MXBean API to What's new in version 0.42.0

Closes #1199
Signed-off-by: Sreekala Gopakumar <sreekala.gopakumar@ibm.com>