### PR TITLE
Correction of the term - SecurityManager

### DIFF
--- a/docs/dcomibmenablelegacydumpsecurity.md
+++ b/docs/dcomibmenablelegacydumpsecurity.md
@@ -24,7 +24,7 @@
 # -Dcom.ibm.enableLegacyDumpSecurity
 
 
-To improve security, the security checks in the certain `com.ibm.jvm.Dump` APIs are now enabled by default, when the `SecurityManger` is enabled. Use this system property to turn off security checking for these APIs.
+To improve security, the security checks in the certain `com.ibm.jvm.Dump` APIs are now enabled by default, when the `SecurityManager` is enabled. Use this system property to turn off security checking for these APIs.
 
 ## Syntax
 
@@ -49,4 +49,4 @@ Security checking is enabled in the following APIs:
 - [-Dcom.ibm.enableLegacyTraceSecurity](dcomibmenablelegacytracesecurity.md)
 
 
-<!-- ==== END OF TOPIC ==== dcomibmenableclasscaching.md ==== -->
+<!-- ==== END OF TOPIC ==== dcomibmenablelegacydumpsecurity.md ==== -->

--- a/docs/dcomibmenablelegacylogsecurity.md
+++ b/docs/dcomibmenablelegacylogsecurity.md
@@ -24,7 +24,7 @@
 # -Dcom.ibm.enableLegacyLogSecurity
 
 
-To improve security, the security checks in the certain `com.ibm.jvm.Log` APIs are now enabled by default, when the `SecurityManger` is enabled. Use this system property to turn off security checking for these APIs.
+To improve security, the security checks in the certain `com.ibm.jvm.Log` APIs are now enabled by default, when the `SecurityManager` is enabled. Use this system property to turn off security checking for these APIs.
 
 ## Syntax
 
@@ -49,4 +49,4 @@ Security checking is enabled in the following APIs:
 - [-Dcom.ibm.enableLegacyTraceSecurity](dcomibmenablelegacytracesecurity.md)
 
 
-<!-- ==== END OF TOPIC ==== dcomibmenableclasscaching.md ==== -->
+<!-- ==== END OF TOPIC ==== dcomibmenablelegacylogsecurity.md ==== -->

--- a/docs/dcomibmenablelegacytracesecurity.md
+++ b/docs/dcomibmenablelegacytracesecurity.md
@@ -24,7 +24,7 @@
 # -Dcom.ibm.enableLegacyTraceSecurity
 
 
-To improve security, the security checks in certain `com.ibm.jvm.Trace` APIs are now enabled by default, when the `SecurityManger` is enabled. Use this system property to turn off security checking for these APIs.
+To improve security, the security checks in certain `com.ibm.jvm.Trace` APIs are now enabled by default, when the `SecurityManager` is enabled. Use this system property to turn off security checking for these APIs.
 
 ## Syntax
 
@@ -55,4 +55,4 @@ Security checking is enabled in the following APIs:
 
 
 
-<!-- ==== END OF TOPIC ==== dcomibmenableclasscaching.md ==== -->
+<!-- ==== END OF TOPIC ==== dcomibmenablelegacytracesecurity.md ==== -->


### PR DESCRIPTION
https://github.ibm.com/runtimes/idteam/issues/1306

The term SecurityManager was misspelled as SecurityManger and the file name in the End of Topic comment was incorrect. Corrections made.

Signed-off-by: Sreekala Gopakumar <sreekala.gopakumar@ibm.com>