### PR TITLE
Miscellaneous tasks for 0.42.0 release

### DIFF
--- a/docs/migrating17to21.md
+++ b/docs/migrating17to21.md
@@ -1,0 +1,50 @@
+<!--
+* Copyright (c) 2017, 2023 IBM Corp. and others
+*
+* This program and the accompanying materials are made
+* available under the terms of the Eclipse Public License 2.0
+* which accompanies this distribution and is available at
+* https://www.eclipse.org/legal/epl-2.0/ or the Apache
+* License, Version 2.0 which accompanies this distribution and
+* is available at https://www.apache.org/licenses/LICENSE-2.0.
+*
+* This Source Code may also be made available under the
+* following Secondary Licenses when the conditions for such
+* availability set forth in the Eclipse Public License, v. 2.0
+* are satisfied: GNU General Public License, version 2 with
+* the GNU Classpath Exception [1] and GNU General Public
+* License, version 2 with the OpenJDK Assembly Exception [2].
+*
+* [1] https://www.gnu.org/software/classpath/license.html
+* [2] https://openjdk.org/legal/assembly-exception.html
+*
+* SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH
+* Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+-->
+
+
+# Migrating from Java 17 to Java 21
+
+Support for OpenJDK 21 was added in Eclipse OpenJ9&trade; version 0.42.0.
+
+The following new OpenJ9 changes apply when OpenJ9 is built with Java&reg; SE 21 class libraries. This information exists elsewhere in the documentation but is summarized here for convenience.
+
+## Support for JDK enhancement proposals (JEP)
+
+The new JEPs that are supported are listed in the following topics:
+
+- JDK 18: [What's new in version 0.32.0](version0.32.md)
+- JDK 19: [What's new in version 0.37.0](version0.37.md)
+- JDK 20: [What's new in version 0.39.0](version0.39.md)
+- JDK 21: [What's new in version 0.42.0](version0.42.md)
+
+## New OpenJ9 features and changes
+
+The following table lists the new OpenJ9 features and notable changes with the OpenJ9 release in which they were added:
+
+| Features and changes  | OpenJ9 release  |
+|-----------------------|-----------------|
+| The OpenJ9 `jextract` tool is removed. | 0.41.0  |
+| New `-XX:[+\|-]ShowCarrierFrames` option added. You can use the `-XX:+ShowCarrierFrames` option to add the stack trace of the carrier thread in addition to the virtual thread stack trace to the `Throwable.getStackTrace()` method, if an exception occurs. | 0.41.0  |
+| New `-XX:ContinuationCache` option added. You can optimize the virtual thread performance by tuning the continuation tier 1 and 2 cache size with the `-XX:ContinuationCache` option | 0.41.0  |
+| Warnings are issued when the agents are loaded dynamically into a running VM after startup without specifying the `-XX:+EnableDynamicAgentLoading` option and the same agents were not loaded before. |  0.41.0    |

--- a/docs/version0.42.md
+++ b/docs/version0.42.md
@@ -28,6 +28,7 @@ The following new features and notable changes since version 0.41.0 are included
 - [New binaries and changes to supported environments](#binaries-and-supported-environments)
 - ![Start of content that applies to Java 21 (LTS) and later](cr/java21plus.png) [OpenJ9 `jextract` removed](#openj9-jextract-removed) ![End of content that applies to Java 21 (LTS) and later](cr/java_close_lts.png)
 - [Change in the `System.gc()` call behavior](#change-in-the-systemgc-call-behavior)
+- ![Start of content that applies to Java 21 (LTS) and later](cr/java21plus.png) [New JDK 21 features](#new-jdk-21-features) ![End of content that applies to Java 21 (LTS) and later](cr/java_close_lts.png)
 
 ## Features and changes
 
@@ -50,6 +51,32 @@ The `System.gc` call triggers a global garbage collection (GC) cycle, which is a
 Now, the `System.gc()` call triggers the GC cycle twice internally to clear the unreachable objects that were not identified during the first GC cycle. The call also triggers finalization of the objects in the Finalization queues.
 
 For more information, see [Garbage collection](gc_overview.md).
+
+### ![Start of content that applies to Java 21 plus](cr/java21plus.png) New JDK 21 features
+
+The following features are supported by OpenJ9:
+
+- [JEP 440](https://openjdk.java.net/jeps/440): Record Patterns
+- [JEP 442](https://openjdk.java.net/jeps/442): Foreign Function & Memory API (Third Preview)
+- [JEP 444](https://openjdk.java.net/jeps/444): Virtual Threads
+- [JEP 446](https://openjdk.java.net/jeps/446): Scoped Values (Preview)
+- [JEP 448](https://openjdk.java.net/jeps/448): Vector API (Sixth Incubator)
+- [JEP 451](https://openjdk.java.net/jeps/451): Prepare to Disallow the Dynamic Loading of Agents
+- [JEP 453](https://openjdk.java.net/jeps/453): Structured Concurrency (Preview)
+
+
+The following features are implemented in OpenJDK and available in any build of OpenJDK 21 with OpenJ9:
+
+- [JEP 430](https://openjdk.java.net/jeps/430): String Templates (Preview)
+- [JEP 431](https://openjdk.java.net/jeps/431): Sequenced Collections
+- [JEP 441](https://openjdk.java.net/jeps/441): Pattern Matching for switch
+- [JEP 443](https://openjdk.java.net/jeps/443): Unnamed Patterns and Variables (Preview)
+- [JEP 445](https://openjdk.java.net/jeps/445): Unnamed Classes and Instance Main Methods (Preview)
+- [JEP 452](https://openjdk.java.net/jeps/452): Key Encapsulation Mechanism API
+
+
+You can find the full list of features for JDK 21 at the [OpenJDK project](http://openjdk.java.net/projects/jdk/21/).
+Any remaining features that are listed either do not apply to OpenJ9 or are not implemented and hence not applicable to OpenJ9 in this release. ![End of content that applies to Java 21 (LTS) and later](cr/java_close_lts.png)
 
 ## Known problems and full release information
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -140,6 +140,7 @@ nav:
     - "Migrating" :
         - "Migrating from Java 8 to Java 11"                                     : migrating8to11.md
         - "Migrating from Java 11 to Java 17"                                    : migrating11to17.md
+        - "Migrating from Java 17 to Java 21"                                    : migrating17to21.md
         
     - "Configuring your system"                                                  : configuring.md
 


### PR DESCRIPTION
Created a new topic - Migrating from Java 17 to Java 21 and included the JEPs for Java 21 in the What's new in version 0.42.0

Signed-off-by: Sreekala Gopakumar <sreekala.gopakumar@ibm.com>