### PR TITLE
Change http://openjdk.java.net to https://openjdk.org

### DIFF
--- a/docs/version0.37.md
+++ b/docs/version0.37.md
@@ -88,7 +88,7 @@ The following features are implemented in OpenJDK and available in any build of 
 - [JEP 405](https://openjdk.java.net/jeps/405): Record Patterns (Preview)
 - [JEP 427](https://openjdk.java.net/jeps/427): Pattern Matching for switch (Third Preview)
 
-You can find the full list of features for JDK 19 at the [OpenJDK project](http://openjdk.java.net/projects/jdk/19/).
+You can find the full list of features for JDK 19 at the [OpenJDK project](https://openjdk.org/projects/jdk/19/).
 Any remaining features that are listed are not implemented and hence not applicable to OpenJ9 in this release.
 
 ## Known problems and full release information

--- a/docs/version0.39.md
+++ b/docs/version0.39.md
@@ -59,7 +59,7 @@ The following features are implemented in OpenJDK and available in any build of 
 - [JEP 432](https://openjdk.java.net/jeps/432): Record Patterns (Second Preview)
 - [JEP 433](https://openjdk.java.net/jeps/433): Pattern Matching for switch (Fourth Preview)
 
-You can find the full list of features for JDK 20 at the [OpenJDK project](http://openjdk.java.net/projects/jdk/20/).
+You can find the full list of features for JDK 20 at the [OpenJDK project](https://openjdk.org/projects/jdk/20/).
 Any remaining features that are listed either do not apply to OpenJ9 or are not implemented and hence not applicable to OpenJ9 in this release.
 
 ## Known problems and full release information

--- a/docs/version0.42.md
+++ b/docs/version0.42.md
@@ -80,7 +80,7 @@ The following features are implemented in OpenJDK and available in any build of 
 - [JEP 452](https://openjdk.java.net/jeps/452): Key Encapsulation Mechanism API
 
 
-You can find the full list of features for JDK 21 at the [OpenJDK project](http://openjdk.java.net/projects/jdk/21/).
+You can find the full list of features for JDK 21 at the [OpenJDK project](https://openjdk.org/projects/jdk/21/).
 Any remaining features that are listed either do not apply to OpenJ9 or are not implemented and hence not applicable to OpenJ9 in this release. ![End of content that applies to Java 21 (LTS) and later](cr/java_close_lts.png)
 
 ## Known problems and full release information


### PR DESCRIPTION
Changed http://openjdk.java.net to https://openjdk.org in topics.

Signed-off-by: Sreekala Gopakumar <sreekala.gopakumar@ibm.com>