### PR TITLE
Compile Windows with VS2022, x,p,zlinux to gcc 11.2 alinux to 10.3

### DIFF
--- a/docs/openj9_support.md
+++ b/docs/openj9_support.md
@@ -258,12 +258,12 @@ The project builds and tests OpenJDK with OpenJ9 on a number of platforms. The o
 
 | Platform                      | Operating system       | Compiler                              |
 |-------------------------------|------------------------|---------------------------------------|
-| Linux x86 64-bit              | CentOS 6.10            | gcc 7.5                               |
-| Linux on POWER&reg; LE 64-bit | CentOS 7.9             | gcc 7.5                               |
-| Linux on IBM Z&reg; 64-bit    | RHEL 7.9               | gcc 7.5                               |
-| Linux AArch64 64-bit          | CentOS 7.9             | gcc 7.5                               |
-| Windows x86 32-bit            | Windows Server 2019    | Microsoft Visual Studio 2019          |
-| Windows x86 64-bit            | Windows Server 2019    | Microsoft Visual Studio 2019          |
+| Linux x86 64-bit              | CentOS 6.10            | gcc 11.2                              |
+| Linux on POWER&reg; LE 64-bit | CentOS 7.9             | gcc 11.2                              |
+| Linux on IBM Z&reg; 64-bit    | RHEL 7.9               | gcc 11.2                              |
+| Linux AArch64 64-bit          | CentOS 7.9             | gcc 10.3                              |
+| Windows x86 32-bit            | Windows Server 2019    | Microsoft Visual Studio 2022          |
+| Windows x86 64-bit            | Windows Server 2019    | Microsoft Visual Studio 2022          |
 | macOS x86 64-bit              | OSX 10.15.7            | xcode 12.4 and clang 12.0.0           |
 | AIX POWER BE 64-bit           | AIX 7.2 TL5            | xlc/C++ 13.1.3                        |
 
@@ -271,11 +271,11 @@ The project builds and tests OpenJDK with OpenJ9 on a number of platforms. The o
 
 | Platform                      | Operating system       | Compiler                              |
 |-------------------------------|------------------------|---------------------------------------|
-| Linux x86 64-bit              | CentOS 6.10            | gcc 7.5                               |
-| Linux on POWER LE 64-bit      | CentOS 7.9             | gcc 7.5                               |
-| Linux on IBM Z 64-bit         | RHEL 7.9               | gcc 7.5                               |
-| Linux AArch64 64-bit          | CentOS 7.9             | gcc 7.5                               |
-| Windows x86 64-bit            | Windows Server 2019    | Microsoft Visual Studio 2019          |
+| Linux x86 64-bit              | CentOS 6.10            | gcc 11.2                              |
+| Linux on POWER LE 64-bit      | CentOS 7.9             | gcc 11.2                              |
+| Linux on IBM Z 64-bit         | RHEL 7.9               | gcc 11.2                              |
+| Linux AArch64 64-bit          | CentOS 7.9             | gcc 10.3                              |
+| Windows x86 64-bit            | Windows Server 2019    | Microsoft Visual Studio 2022          |
 | macOS x86 64-bit              | macOS 10.15.7          | xcode 12.4 and clang 12.0.0           |
 | macOS AArch64                 | macOS 11.5.2           | xcode 13.0 and clang 13.0.0           |
 | AIX POWER BE 64-bit           | AIX 7.2 TL5            | xlc/C++ 16.1.0.11                     |
@@ -284,11 +284,11 @@ The project builds and tests OpenJDK with OpenJ9 on a number of platforms. The o
 
 | Platform                      | Operating system       | Compiler                              |
 |-------------------------------|------------------------|---------------------------------------|
-| Linux x86 64-bit              | CentOS 7.9             | gcc 10.3                              |
-| Linux on POWER LE 64-bit      | CentOS 7.9             | gcc 10.3                              |
-| Linux on IBM Z 64-bit         | RHEL 7.9               | gcc 10.3                              |
+| Linux x86 64-bit              | CentOS 7.9             | gcc 11.2                              |
+| Linux on POWER LE 64-bit      | CentOS 7.9             | gcc 11.2                              |
+| Linux on IBM Z 64-bit         | RHEL 7.9               | gcc 11.2                              |
 | Linux AArch64 64-bit          | CentOS 7.9             | gcc 10.3                              |
-| Windows x86 64-bit            | Windows Server 2019    | Microsoft Visual Studio 2019          |
+| Windows x86 64-bit            | Windows Server 2019    | Microsoft Visual Studio 2022          |
 | macOS x86 64-bit              | macOS 10.15.7          | xcode 12.4 and clang 12.0.0           |
 | macOS AArch64                 | macOS 11.5.2           | xcode 13.0 and clang 13.0.0           |
 | AIX POWER BE 64-bit           | AIX 7.2 TL5            | xlc/C++ 16.1.0.11                     |

--- a/docs/version0.43.md
+++ b/docs/version0.43.md
@@ -1,0 +1,53 @@
+<!--
+* Copyright (c) 2017, 2024 IBM Corp. and others
+*
+* This program and the accompanying materials are made
+* available under the terms of the Eclipse Public License 2.0
+* which accompanies this distribution and is available at
+* https://www.eclipse.org/legal/epl-2.0/ or the Apache
+* License, Version 2.0 which accompanies this distribution and
+* is available at https://www.apache.org/licenses/LICENSE-2.0.
+*
+* This Source Code may also be made available under the
+* following Secondary Licenses when the conditions for such
+* availability set forth in the Eclipse Public License, v. 2.0
+* are satisfied: GNU General Public License, version 2 with
+* the GNU Classpath Exception [1] and GNU General Public
+* License, version 2 with the OpenJDK Assembly Exception [2].
+*
+* [1] https://www.gnu.org/software/classpath/license.html
+* [2] https://openjdk.org/legal/assembly-exception.html
+*
+* SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0 OR GPL-2.0-only WITH OpenJDK-assembly-exception-1.0
+-->
+
+# What's new in version 0.43.0
+
+The following new features and notable changes since version 0.42.0 are included in this release:
+
+- [New binaries and changes to supported environments](#binaries-and-supported-environments)
+- [Compiler changes for Linux&reg;](#compiler-changes-for-linux)
+
+## Features and changes
+
+### Binaries and supported environments
+
+Eclipse OpenJ9&trade; release 0.43.0 supports OpenJDK 8, 11, 17, and 21.
+
+OpenJ9 Windows&reg; builds for OpenJDK 8, 11, and 17 are now compiled with Microsoft&reg; Visual Studio 2022. The Visual Studio redistributable files included with the build are updated to match.
+
+To learn more about support for OpenJ9 releases, including OpenJDK levels and platform support, see [Supported environments](openj9_support.md).
+
+### Compiler changes for Linux
+
+Linux x86 64-bit, Linux on POWER&reg; LE 64-bit, and Linux on IBM Z&reg; 64-bit builds on OpenJDK 8, 11, and 17 now use gcc 11.2 compiler. Linux AArch64 64-bit moved to gcc 10.3 compiler from gcc 7.5 compiler on OpenJDK 8 and 11.
+
+On OpenJDK 19 and later, Linux reference compiler was already updated to gcc 11.2 in [release 0.37.0](version0.37.md).
+
+See [Supported environments](openj9_support.md).
+
+## Known problems and full release information
+
+To see known problems and a complete list of changes between Eclipse OpenJ9 v0.42.0 and v0.43.0 releases, see the [Release notes](https://github.com/eclipse-openj9/openj9/blob/master/doc/release-notes/0.43/0.43.md).
+
+<!-- ==== END OF TOPIC ==== version0.43.md ==== -->

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -101,6 +101,7 @@ nav:
 
     - "Release notes" :
         - "Overview"                                                             : openj9_releases.md
+        - "Version 0.43.0"                                                       : version0.43.md
         - "Version 0.42.0"                                                       : version0.42.md
         - "Version 0.41.0"                                                       : version0.41.md
         - "Version 0.40.0"                                                       : version0.40.md


### PR DESCRIPTION
https://github.com/eclipse-openj9/openj9-docs/issues/1168

Updated the compiler details for Linux and Windows.

Closes #1168
Signed-off-by: Sreekala Gopakumar <sreekala.gopakumar@ibm.com>