### PR TITLE
Code cache allocation changes with Large pages enabled

### DIFF
--- a/docs/configuring.md
+++ b/docs/configuring.md
@@ -159,12 +159,14 @@ The following guides are available to help you configure Language Environment ru
 
 If your application allocates a large amount of memory and frequently accesses that memory, you might be able to improve performance by enabling large page support on your system.
 
-Some Linux kernels implement Transparent HugePage Support (THP), which automates the provision of large pages to back virtual memory, as described in [Linux systems](#linux-systems). Alternatively, you can enable large page support by setting the [`-Xlp:objectheap`](xlpobjectheap.md) and [`-Xlp:codecache`](xlpcodecache.md) options on the command line when you start your application. These options have the following effects:
+Some Linux kernels implement Transparent HugePage Support (THP), which automates the provision of large pages to back virtual memory, as described in [Linux systems](#linux-systems). Alternatively, you can configure the VM to use large pages (if the large pages support is enabled on the system) by setting the [`-Xlp:objectheap`](xlpobjectheap.md) and [`-Xlp:codecache`](xlpcodecache.md) options on the command line when you start your application. These options have the following effects:
 
 - The `-Xlp:objectheap` option requests that the Java object heap is allocated by using large pages.
 - The `-Xlp:codecache` option requests that the JIT code cache is allocated by using large pages.
 
-You must also enable large pages on your local system. This process differs according to the operating system.
+    If the configured large page size is greater than the size of the total JIT code cache, the next available lower page size on the system is used for the code cache allocation.
+
+The process for enabling the large page support differs in different operating systems, as explained in the following sections.
 
 ### AIX systems
 

--- a/docs/version0.43.md
+++ b/docs/version0.43.md
@@ -27,6 +27,7 @@ The following new features and notable changes since version 0.42.0 are included
 
 - [New binaries and changes to supported environments](#binaries-and-supported-environments)
 - [Compiler changes for Linux&reg;](#compiler-changes-for-linux)
+- [Change in the large page memory allocation behavior](#change-in-the-large-page-memory-allocation-behavior)
 
 ## Features and changes
 
@@ -42,9 +43,17 @@ To learn more about support for OpenJ9 releases, including OpenJDK levels and pl
 
 Linux x86 64-bit, Linux on POWER&reg; LE 64-bit, and Linux on IBM Z&reg; 64-bit builds on OpenJDK 8, 11, and 17 now use gcc 11.2 compiler. Linux AArch64 64-bit moved to gcc 10.3 compiler from gcc 7.5 compiler on OpenJDK 8 and 11.
 
-On OpenJDK 19 and later, Linux reference compiler was already updated to gcc 11.2 in [release 0.37.0](version0.37.md).
+On OpenJDK 19 and later, the Linux reference compiler was already updated to gcc 11.2 in [release 0.37.0](version0.37.md).
 
-See [Supported environments](openj9_support.md).
+For more information, see [Supported environments](openj9_support.md).
+
+### Change in the large page memory allocation behavior
+
+Earlier, the JIT code cache was allocated memory as a multiple of the available page size even if the configured large page size was greater than the total JIT code cache size.
+
+Now, if the configured large page size is greater than the size of the total code cache for JIT, then the page size that is used for code cache allocation is recalculated. The next available lower page size on the platform is used for the code cache allocation.
+
+For more information, see [`-Xlp:codecache`](xlpcodecache.md).
 
 ## Known problems and full release information
 

--- a/docs/xlp.md
+++ b/docs/xlp.md
@@ -31,13 +31,19 @@ Requests the Eclipse OpenJ9&trade; VM to allocate the Java&trade; object heap an
 
 If you use the [`-Xgc:preferredHeapBase`](xgc.md#preferredheapbase) option with `-Xlp`, the preferredHeapBase address must be a multiple of the large page size. If you specify an inaccurate heap base address, the heap is allocated with the default page size.
 
-To find out the large page sizes available and the current setting, use the `-verbose:sizes` option. Note that the current settings are the requested sizes and not the sizes obtained. For object heap size information, check the `-verbose:gc` output.
+To find out the large page sizes available and the current setting, use the `-verbose:sizes` option. These current settings are the requested sizes and not the sizes obtained. For object heap size information, check the `-verbose:gc` output.
+
+To use the large pages in the VM, enable the large pages support in the operating system for the machine to be used. The process for enabling the large page support differs in different operating systems. For more information, see [Configuring large page memory allocation](configuring.md#configuring-large-page-memory-allocation).
+
+If the configured large page size is greater than the size of the total code cache for JIT, then the page size that is used for code cache allocation is recalculated. The next available lower page size on the system is identified and used for the code cache allocation.
+
+For example, if 1 GB, 2 MB and 4 KB pages are available on a system, the VM checks the total size of the JIT code cache. If the total JIT code cache size is not modified (by using the [`-Xcodecachetotal`](xcodecachetotal.md) option), then for a 64-bit VM, the JIT code cache size will be the default size, 256 MB. In this case, the VM does not use 1 GB pages for the code cache because the size of the page exceeds the total size of the code cache (256 MB for 64-bit systems). Thus, the next available page size lower than 256 MB is used for code cache allocation. In this example, the next available lower size page is 2 MB. 128 pages (of 2 MB each) are allocated for the code cache.
 
 ## Syntax
 
         -Xlp[<size>]
 
-See [Using -X command-line options](x_jvm_commands.md) for more information about the `<size>` parameter.
+For more information about the `<size>` parameter, see [Using -X command-line options](x_jvm_commands.md).
 
 ## Explanation
 

--- a/docs/xlpcodecache.md
+++ b/docs/xlpcodecache.md
@@ -27,7 +27,13 @@ Requests the Eclipse OpenJ9&trade; VM to allocate the JIT code cache by using la
 
 If the requested large page size is not available, the VM starts, but the JIT code cache is allocated by using a platform-defined size. A warning is displayed when the requested page size is not available.
 
-To find out the large page sizes available and the current setting, use the `-verbose:sizes` option. Note that the current settings are the requested sizes and not the sizes obtained. For object heap size information, check the `-verbose:gc` output.
+To find out the large page sizes available and the current setting, use the `-verbose:sizes` option. These current settings are the requested sizes and not the sizes obtained. For object heap size information, check the `-verbose:gc` output.
+
+To use the large pages in the VM, enable the large pages support on your local system. The process for enabling the large page support differs in different operating systems. For more information, see [Configuring large page memory allocation](configuring.md#configuring-large-page-memory-allocation).
+
+If the configured large page size is greater than the size of the total code cache for JIT, then the page size that is used for code cache allocation is recalculated. The next available lower page size on the system is identified and used for the code cache allocation.
+
+For example, if 1 GB, 2 MB and 4 KB pages are available on a system, the VM checks the total size of the JIT code cache. If the total JIT code cache size is not modified (by using the [`-Xcodecachetotal`](xcodecachetotal.md) option), then for a 64-bit VM, the JIT code cache size will be the default size, 256 MB. In this case, the VM does not use 1 GB pages for the code cache because the size of the page exceeds the total size of the code cache (256 MB for 64-bit systems). Thus, the next available page size lower than 256 MB is used for code cache allocation. In this example, the next available lower size page is 2 MB. 128 pages (of 2 MB each) are allocated for the code cache.
 
 ## Syntax
 
@@ -39,7 +45,7 @@ z/OS&reg;:
 
         -Xlp:codecache:pagesize=<size>,pageable
 
-See [Using -X command-line options](x_jvm_commands.md) for more information about the `<size>` parameter.
+For more information about the `<size>` parameter, see [Using -X command-line options](x_jvm_commands.md).
 
 ## Default values
 
@@ -70,7 +76,7 @@ See [Using -X command-line options](x_jvm_commands.md) for more information abou
 
 ## See also
 
-- [Configuring large page memory allocation](configuring.md#configuring-large-page-memory-allocation).
+- [Configuring large page memory allocation](configuring.md#configuring-large-page-memory-allocation)
 
 
 


### PR DESCRIPTION
https://github.com/eclipse-openj9/openj9-docs/issues/1206

Updated the related topics with the information of the change in the large page memory allocation behavior.

Closes #1206
Signed-off-by: Sreekala Gopakumar <sreekala.gopakumar@ibm.com>