### PR TITLE
Don't build the docker container on ub18, it doesn't work

### DIFF
--- a/JenkinsFile_build_container.groovy
+++ b/JenkinsFile_build_container.groovy
@@ -25,7 +25,7 @@ CONTAINER_NAME = 'openj9-docs'
 
 timeout(time: 6, unit: 'HOURS') {
     timestamps {
-        node('hw.arch.x86&&sw.tool.docker') {
+        node('hw.arch.x86&&sw.tool.docker&&!sw.os.ubuntu.18') {
             try {
                 stage('Clone') {
                     checkout scm


### PR DESCRIPTION
I've only seen it fail on ub18-x86-1 but removing all ub18 just in case.

https://openj9-jenkins.osuosl.org/view/Website-Doc/job/Build-Doc-Docker_Container/15/

```
15:55:52  Err:1 http://archive.ubuntu.com/ubuntu jammy InRelease
15:55:52    The following signatures couldn't be verified because the
public key is not available: NO_PUBKEY 871920D1991BC93C
```