### PR TITLE
New -XX:Compatibility=elasticsearch option

### DIFF
--- a/docs/version0.43.md
+++ b/docs/version0.43.md
@@ -29,6 +29,7 @@ The following new features and notable changes since version 0.42.0 are included
 - [Compiler changes for Linux&reg;](#compiler-changes-for-linux)
 - [Change in the large page memory allocation behavior](#change-in-the-large-page-memory-allocation-behavior)
 - ![Start of content that applies to Java 11 (LTS) and later](cr/java11plus.png) [New `-XX:[+|-]CRIUSecProvider` option added](#new-xx-criusecprovider-option-added) ![End of content that applies to Java 11 (LTS) and later](cr/java_close.png)
+- [New `-XX:Compatibility` option added](#new-xxcompatibility-option-added)
 
 ## Features and changes
 
@@ -63,6 +64,14 @@ When you enable CRIU support, all the existing security providers are removed fr
 You can now control the use of `CRIUSECProvider` during the checkpoint phase with the `-XX:[+|-]CRIUSecProvider` option. You can use all the existing security providers instead of the `CRIUSECProvider` by specifying the `-XX:-CRIUSecProvider` option.
 
 For more information, see [`-XX:[+|-]CRIUSecProvider`](xxcriusecprovider.md). ![End of content that applies to Java 11 (LTS) and later](cr/java_close.png)
+
+### New `-XX:Compatibility` option added
+
+The Elasticsearch application was facing incompatibility issues when it was running on OpenJ9 and required many workarounds. With the `-XX:Compatibility` option, you can enable a compatibility mode that OpenJ9 can run in to support applications that require specific capabilities.
+
+In release 0.43.0, the compatibility mode is provided for the Elasticsearch application only.
+
+For more information, see [`-XX:Compatibility`](xxcompatibility.md).
 
 ## Known problems and full release information
 

--- a/docs/xxcompatibility.md
+++ b/docs/xxcompatibility.md
@@ -1,0 +1,47 @@
+<!--
+* Copyright (c) 2017, 2024 IBM Corp. and others
+*
+* This program and the accompanying materials are made
+* available under the terms of the Eclipse Public License 2.0
+* which accompanies this distribution and is available at
+* https://www.eclipse.org/legal/epl-2.0/ or the Apache
+* License, Version 2.0 which accompanies this distribution and
+* is available at https://www.apache.org/licenses/LICENSE-2.0.
+*
+* This Source Code may also be made available under the
+* following Secondary Licenses when the conditions for such
+* availability set forth in the Eclipse Public License, v. 2.0
+* are satisfied: GNU General Public License, version 2 with
+* the GNU Classpath Exception [1] and GNU General Public
+* License, version 2 with the OpenJDK Assembly Exception [2].
+*
+* [1] https://www.gnu.org/software/classpath/license.html
+* [2] https://openjdk.org/legal/assembly-exception.html
+*
+* SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0 OR GPL-2.0-only WITH OpenJDK-assembly-exception-1.0
+-->
+
+# -XX:Compatibility
+
+This option enables a compatibility mode that OpenJ9 can run in to support applications that require specific capabilities. For example, support for applications that rely on vendor-specific command line arguments or to make available unspecified APIs.
+
+## Syntax
+
+        -XX:Compatibility=<mode>
+
+Where, `<mode>` is the application for which the compatibility mode is provided. The `<mode>` is case-insensitive.
+
+In release 0.43.0, the compatibility mode is provided for the Elasticsearch application only.
+
+        -XX:Compatibility=Elasticsearch
+
+If the `-XX:Compatibility` option is specified more than once, or with a mode other than "Elasticsearch" (not case-sensitive), the VM fails to start.
+
+Although this option is available in all OpenJDK versions, the Elasticsearch application requires OpenJDK version 17 or later.
+
+## Explanation
+
+The Elasticsearch application was facing incompatibility issues when it was running on OpenJ9 and required many workarounds. With the `Elasticsearch` compatibility mode, OpenJ9 accepts and supports HotSpot-specific options or APIs that enhance compatibility to run the Elasticsearch application.
+
+
+<!-- ==== END OF TOPIC ==== xxcompatibility.md ==== -->

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -170,6 +170,7 @@ nav:
            - "-Xrs:onRestore / -Xrs:syncOnRestore"                               : xrsonrestoresynconrestore.md
            - "-Xshareclasses:disableOnRestore"                                   : xshareclassesdisableonrestore.md
            - "-XX:CheckpointGCThreads"                                           : xxcheckpointgcthread.md
+           - "-XX:Compatibility"                                                 : xxcompatibility.md
            - "-XX:[+|-]CRIURestoreNonPortableMode"                               : xxcriurestorenonportablemode.md
            - "-XX:[+|-]CRIUSecProvider"                                          : xxcriusecprovider.md
            - "-XX:[+|-]EnableCRIUSupport"                                        : xxenablecriusupport.md


### PR DESCRIPTION
https://github.com/eclipse-openj9/openj9-docs/issues/1213

Added new topic for the new option, -XX:Compatibility=elasticsearch. Updated the What's new topic and mkdocs.yml file.

Closes #1213
Signed-off-by: Sreekala Gopakumar <sreekala.gopakumar@ibm.com>