### PR TITLE
(0.42) Document support for JITServer on Linux on Aarch64

### DIFF
--- a/docs/jitserver.md
+++ b/docs/jitserver.md
@@ -23,7 +23,7 @@
 
 # JITServer technology
 
-**Linux&reg; on x86, Linux on IBM Power&reg; systems, and Linux on IBM Z&reg; systems (64-bit only)**
+**Linux&reg; on x86, Linux on IBM Power&reg; systems, Linux on AArch64 and Linux on IBM Z&reg; systems (64-bit only)**
 
 JITServer technology decouples the JIT compiler from the VM and lets the JIT compiler run remotely in its own process. This mechanism prevents your Java&trade; application suffering possible negative effects due to CPU and memory consumption caused by JIT compilation.
 

--- a/docs/version0.41.md
+++ b/docs/version0.41.md
@@ -36,6 +36,7 @@ The following new features and notable changes since version 0.40.0 are included
 - [Performance improvement](#performance-improvement)
 - [Support added for the `com.sun.management.ThreadMXBean.getThreadAllocatedBytes()` API](#support-added-for-the-comsunmanagementthreadmxbeangetthreadallocatedbytes-api)
 - [Change in behavior of the `-Djava.security.manager` system property for OpenJDK version 8 and 11](#change-in-behavior-of-the-djavasecuritymanager-system-property-for-openjdk-version-8-and-11)
+- [JITServer support for Linux on AArch64](#jitserver-support-for-linux-on-aarch64)
 
 ## Features and changes
 
@@ -100,6 +101,9 @@ Support for the `com.sun.management.ThreadMXBean.getThreadAllocatedBytes()` API 
 From OpenJDK version 18 onwards, if you enable the `SecurityManager` at runtime by calling the `System.setSecurityManager()` API, you must set the `-Djava.security.manager=allow` option. To disable the `SecurityManager`, you must specify the `-Djava.security.manager=disallow` option. If an application is designed to run on multiple OpenJDK versions, the same command line might be used across multiple versions. Because of this use of the same command line across multiple versions, in OpenJDK versions before version 18, the runtime attempts to load a `SecurityManager` with the class name `allow` or `disallow` resulted in an error and the application was not starting.
 
 To resolve this issue, OpenJDK version 17 ignores these options. With this release, OpenJDK versions 8 and 11 also ignore the `allow` and `disallow` keywords, if specified.
+
+### JITServer support for Linux on AArch64
+JITServer technology is now a fully supported feature on Linux on AArch64 systems. For more information, see [JITServer technology](jitserver.md).
 
 ## Known problems and full release information
 


### PR DESCRIPTION
https://github.com/eclipse-openj9/openj9-docs/issues/1243

Updated related topics to document that support for JITServer on Linux on aarch64 was enabled in release-0.41

Cherry pick https://github.com/eclipse-openj9/openj9-docs/pull/1252 for 0.42