### PR TITLE
Ignore "allow" and "disallow" options in security manager on jdk8

### DIFF
--- a/docs/version0.41.md
+++ b/docs/version0.41.md
@@ -35,7 +35,7 @@ The following new features and notable changes since version 0.40.0 are included
 - [Support for OpenSSL 3.x](#support-for-openssl-3x)
 - [Performance improvement](#performance-improvement)
 - [Support added for the `com.sun.management.ThreadMXBean.getThreadAllocatedBytes()` API](#support-added-for-the-comsunmanagementthreadmxbeangetthreadallocatedbytes-api)
-- [Change in behavior of the `-Djava.security.manager` system property for OpenJDK version 8 and 11](#change-in-behavior-of-the-djavasecuritymanager-system-property-for-openjdk-version-8-and-11)
+- [Change in behavior of the `-Djava.security.manager` system property for OpenJDK version 11](#change-in-behavior-of-the-djavasecuritymanager-system-property-for-openjdk-version-11)
 - [JITServer support for Linux on AArch64](#jitserver-support-for-linux-on-aarch64)
 
 ## Features and changes
@@ -96,11 +96,11 @@ With this release, the OpenJ9 VM implementation supports thread memory allocatio
 
 Support for the `com.sun.management.ThreadMXBean.getThreadAllocatedBytes()` API is not added on z/OS&reg; platforms in this release. In the coming future z/OS release, the support for this API will be added on z/OS platforms as well.
 
-### Change in behavior of the `-Djava.security.manager` system property for OpenJDK version 8 and 11
+### Change in behavior of the `-Djava.security.manager` system property for OpenJDK version 11
 
 From OpenJDK version 18 onwards, if you enable the `SecurityManager` at runtime by calling the `System.setSecurityManager()` API, you must set the `-Djava.security.manager=allow` option. To disable the `SecurityManager`, you must specify the `-Djava.security.manager=disallow` option. If an application is designed to run on multiple OpenJDK versions, the same command line might be used across multiple versions. Because of this use of the same command line across multiple versions, in OpenJDK versions before version 18, the runtime attempts to load a `SecurityManager` with the class name `allow` or `disallow` resulted in an error and the application was not starting.
 
-To resolve this issue, OpenJDK version 17 ignores these options. With this release, OpenJDK versions 8 and 11 also ignore the `allow` and `disallow` keywords, if specified.
+To resolve this issue, OpenJDK version 17 ignores these options. With this release, OpenJDK version 11 also ignores the `allow` and `disallow` keywords, if specified.
 
 ### JITServer support for Linux on AArch64
 JITServer technology is now a fully supported feature on Linux on AArch64 systems. For more information, see [JITServer technology](jitserver.md).

--- a/docs/version0.44.md
+++ b/docs/version0.44.md
@@ -1,0 +1,49 @@
+<!--
+* Copyright (c) 2017, 2024 IBM Corp. and others
+*
+* This program and the accompanying materials are made
+* available under the terms of the Eclipse Public License 2.0
+* which accompanies this distribution and is available at
+* https://www.eclipse.org/legal/epl-2.0/ or the Apache
+* License, Version 2.0 which accompanies this distribution and
+* is available at https://www.apache.org/licenses/LICENSE-2.0.
+*
+* This Source Code may also be made available under the
+* following Secondary Licenses when the conditions for such
+* availability set forth in the Eclipse Public License, v. 2.0
+* are satisfied: GNU General Public License, version 2 with
+* the GNU Classpath Exception [1] and GNU General Public
+* License, version 2 with the OpenJDK Assembly Exception [2].
+*
+* [1] https://www.gnu.org/software/classpath/license.html
+* [2] https://openjdk.org/legal/assembly-exception.html
+*
+* SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0 OR GPL-2.0-only WITH OpenJDK-assembly-exception-1.0
+-->
+
+# What's new in version 0.44.0
+
+The following new features and notable changes since version 0.43.0 are included in this release:
+
+- [New binaries and changes to supported environments](#binaries-and-supported-environments)
+- [Change in behavior of the `-Djava.security.manager` system property for OpenJDK version 8](#change-in-behavior-of-the-djavasecuritymanager-system-property-for-openjdk-version-8)
+
+## Features and changes
+
+### Binaries and supported environments
+
+Eclipse OpenJ9&trade; release 0.44.0 supports OpenJDK 8, 11, 17, and 21.
+
+To learn more about support for OpenJ9 releases, including OpenJDK levels and platform support, see [Supported environments](openj9_support.md).
+
+### Change in behavior of the `-Djava.security.manager` system property for OpenJDK version 8
+
+From OpenJDK version 18 onwards, if you enable the `SecurityManager` at runtime by calling the `System.setSecurityManager()` API, you must set the `-Djava.security.manager=allow` option. To disable the `SecurityManager`, you must specify the `-Djava.security.manager=disallow` option. If an application is designed to run on multiple OpenJDK versions, the same command line might be used across multiple versions. Because of this use of the same command line across multiple versions, in OpenJDK versions before version 18, the runtime attempts to load a `SecurityManager` with the class name `allow` or `disallow` resulted in an error and the application was not starting.
+
+To resolve this issue, OpenJDK version 17 ignores these options and from 0.41.0 release onwards, OpenJDK version 11 also ignores these options. With this release, OpenJDK version 8 too ignores the `allow` and `disallow` keywords, if specified.
+
+## Known problems and full release information
+
+To see known problems and a complete list of changes between Eclipse OpenJ9 v0.43.0 and v0.44.0 releases, see the [Release notes](https://github.com/eclipse-openj9/openj9/blob/master/doc/release-notes/0.44/0.44.md).
+
+<!-- ==== END OF TOPIC ==== version0.44.md ==== -->

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -101,6 +101,7 @@ nav:
 
     - "Release notes" :
         - "Overview"                                                             : openj9_releases.md
+        - "Version 0.44.0"                                                       : version0.44.md
         - "Version 0.43.0"                                                       : version0.43.md
         - "Version 0.42.0"                                                       : version0.42.md
         - "Version 0.41.0"                                                       : version0.41.md


### PR DESCRIPTION
https://github.com/eclipse-openj9/openj9-docs/issues/1279

Deleted the reference to JDK 8 in Change in behavior of the `-Djava.security.manager` system property point in the What's new in version 0.41.0. Created the What's new in version 0.44.0 topic. Added that the change is now applicable on JDK 8 from 0.44.0 release onwards

Closes #1279
Signed-off-by: Sreekala Gopakumar <sreekala.gopakumar@ibm.com>