### PR TITLE
Single warning message if the same library loaded-AIX

### DIFF
--- a/docs/version0.44.md
+++ b/docs/version0.44.md
@@ -27,7 +27,7 @@ The following new features and notable changes since version 0.43.0 are included
 
 - [New binaries and changes to supported environments](#binaries-and-supported-environments)
 - [Change in behavior of the `-Djava.security.manager` system property for OpenJDK version 8](#change-in-behavior-of-the-djavasecuritymanager-system-property-for-openjdk-version-8)
-
+- ![Start of content that applies to Java 21 (LTS)](cr/java21.png) [Display of multiple warnings on loading the same agent restricted on AIX&reg; systems](#display-of-multiple-warnings-on-loading-the-same-agent-restricted-on-aix-systems) ![End of content that applies to Java 21 (LTS)](cr/java_close_lts.png)
 ## Features and changes
 
 ### Binaries and supported environments
@@ -41,6 +41,14 @@ To learn more about support for OpenJ9 releases, including OpenJDK levels and pl
 From OpenJDK version 18 onwards, if you enable the `SecurityManager` at runtime by calling the `System.setSecurityManager()` API, you must set the `-Djava.security.manager=allow` option. To disable the `SecurityManager`, you must specify the `-Djava.security.manager=disallow` option. If an application is designed to run on multiple OpenJDK versions, the same command line might be used across multiple versions. Because of this use of the same command line across multiple versions, in OpenJDK versions before version 18, the runtime attempts to load a `SecurityManager` with the class name `allow` or `disallow` resulted in an error and the application was not starting.
 
 To resolve this issue, OpenJDK version 17 ignores these options and from 0.41.0 release onwards, OpenJDK version 11 also ignores these options. With this release, OpenJDK version 8 too ignores the `allow` and `disallow` keywords, if specified.
+
+### ![Start of content that applies to Java 21 (LTS) and later](cr/java21plus.png) Display of multiple warnings on loading the same agent restricted on AIX systems
+
+Earlier, on AIX systems, warnings were issued each time the agents were loaded dynamically into a running VM after startup without specifying the `-XX:+EnableDynamicAgentLoading` option, even if the same agents were loaded before.
+
+Now, from 0.44.0 release onwards, AIX systems, like other OpenJ9 supported operating systems, can detect whether an agent was previously loaded or not. Therefore, like other platforms, on AIX systems also, the warnings are issued only once for the same agent when the `-XX:+EnableDynamicAgentLoading` option is not specified.
+
+For more information, see [`-XX:[+|-]EnableDynamicAgentLoading`](xxenabledynamicagentloading.md). ![End of content that applies to Java 21 (LTS) and later](cr/java_close_lts.png)
 
 ## Known problems and full release information
 

--- a/docs/xxenabledynamicagentloading.md
+++ b/docs/xxenabledynamicagentloading.md
@@ -55,11 +55,9 @@ These warnings are issued only once for the same agent when the `-XX:+EnableDyna
 
 If the `-XX:+EnableDynamicAgentLoading` option is set, all agents that are dynamically loaded are considered as approved by the application owner, and therefore, no warnings are issued.
 
-Eclipse OpenJ9&trade; supported operating systems other than AIX&reg; have APIs to determine whether the same agent was loaded before or not, even if an agent is loaded with a platform-independent name or an absolute path to the platform-dependent library.
+Eclipse OpenJ9&trade; supported operating systems have APIs to determine whether the same agent was loaded before or not, even if an agent is loaded with a platform-independent name or an absolute path to the platform-dependent library.
 
-AIX systems cannot detect whether an agent was previously loaded or not if the agent was loaded through a platform-independent name or an absolute path to the platform-dependent library. Therefore, on AIX systems, warnings are issued each time an agent is loaded dynamically through the Attach API (`VirtualMachine.loadAgentLibrary(agent)`) even if the same agent was loaded before through the command-line option (`-agentpath:/Absolute/Path/to/agentLibrary`) at startup.
-
-A fix to restrict this display of multiple warnings on loading the same agent will be available in a later version of OpenJ9. ![End of content that applies to Java 21 (LTS) and later](cr/java_close_lts.png)
+From 0.44.0 release onwards, AIX systems also can detect whether an agent was previously loaded or not if the agent was loaded through a platform-independent name or an absolute path to the platform-dependent library. Therefore, like other platforms, on AIX systems also, the warnings are issued only once for the same agent when the `-XX:+EnableDynamicAgentLoading` option is not specified. ![End of content that applies to Java 21 (LTS) and later](cr/java_close_lts.png)
 
 ## See also
 


### PR DESCRIPTION
https://github.com/eclipse-openj9/openj9-docs/issues/1264

Fix added to restrict display of multiple warnings on loading the same agent on AIX

Closes #1264
Signed-off-by: Sreekala Gopakumar <sreekala.gopakumar@ibm.com>