### PR TITLE
-XX:+CompactStrings is default since 0.41

### DIFF
--- a/docs/cmdline_migration.md
+++ b/docs/cmdline_migration.md
@@ -99,7 +99,6 @@ You can set the following options to make OpenJ9 behave in the same way as HotSp
 |---------------------------------------------|-----------------------------------------------------------------|
 | ![Start of content that applies only to Java 8 (LTS)](cr/java8.png) [`-Djava.lang.string.substring.nocopy=true`](djavalangstringsubstringnocopy.md) |  Avoid String sharing by `String.substring()`. |
 | [`-Xnuma:none`](xnumanone.md)               | Disable non-uniform memory architecture (NUMA) awareness.       |
-| ![Start of content that applies only to Java 11+ (LTS)](cr/java11plus.png)[`-XX:+CompactStrings`](xxcompactstrings.md)| Enables `String` compression.                 |
 | [`-XX:[+|-]HandleSIGABRT`](xxhandlesigabrt.md)    | Force handling of SIGABRT signals to be compatible with HotSpot. |
 
 


### PR DESCRIPTION
https://github.com/eclipse-openj9/openj9-docs/issues/1282

Option removed from the "Creating compatible behavior" table. From 0.41 the default behavior is compatible for this option.

Closes #1282
Signed-off-by: Sreekala Gopakumar <sreekala.gopakumar@ibm.com>