### PR TITLE
jcmd supports VMID query via Java process display name

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .DS_Store
 Thumbs.db
 /.project
+.vscode/settings.json

--- a/docs/dcomibmtoolsattachdisplayname.md
+++ b/docs/dcomibmtoolsattachdisplayname.md
@@ -30,11 +30,13 @@ Change the default display name for the target virtual machine.
         -Dcom.ibm.tools.attach.displayName=<my_display_name>
 
 
-| Setting          | Value   | Default                                                     |
-|------------------|---------|-------------------------------------------------------------|
-| `<my_display_name>` | [string]| The command line invocation used to start the application   |
+| Setting          | Value   |
+|------------------|---------|
+| `<my_display_name>` | [string]|
 
 To change the value for `<my_display_name>` that is recorded by an agent, enter a character string of your choice.
+
+If the display name is not set through the `-Dcom.ibm.tools.attach.displayName` system property, then the main class name along with the application arguments is set as the default display name. For more information, see [Java diagnostic command (`jcmd`) tool](tool_jcmd.md).
 
 ## See also
 

--- a/docs/tool_jcmd.md
+++ b/docs/tool_jcmd.md
@@ -29,15 +29,22 @@ Use the `jcmd` tool to run diagnostic commands on a specified VM.
 
 The command syntax is as follows:
 
-    jcmd [<options>] [<vmid> <arguments>]
+    jcmd [<options>] [<vmid | display name | 0> <arguments>]
 
 Where:
 
-- The available `<options>` are:    
+- The available `<options>` are:
+    - `-l`: lists current Java&trade; processes recognized by the `jcmd` tool. The list includes VMID, which is usually the *process ID* (pid) and the display name, which refers to the target Java VM process that can be attached by `jcmd`. `-l` is the default option, therefore specifying `jcmd` without any options also displays the VMIDs.
     - `-J`: supplies arguments to the Java VM that is running the `jcmd` command. You can use multiple `-J` options, for example: `jcmd -J-Xmx10m -J-Dcom.ibm.tools.attach.enable=yes`
     - `-h`: prints the `jcmd` help
 
-- `<vmid>` is the Attach API virtual machine identifier for the Java&trade; VM process. This ID is often, but not always, the same as the operating system *process ID*. One example where the ID might be different is if you specified the system property `-Dcom.ibm.tools.attach.id` when you started the process. You can use the [`jps`](tool_jps.md) command to find the VMID.
+- `<vmid>` is the Attach API virtual machine identifier for the Java VM process. This ID is often, but not always, the same as the operating system pid. One example where the ID might be different is if you specified the system property `-Dcom.ibm.tools.attach.id` when you started the process. In addition to the `jcmd` command, you can also use the [`jps`](tool_jps.md) command to find the VMID.
+
+    You can also specify the full or partial target Java process display name instead of the VMID. The `jcmd` tool finds the corresponding VMID of the display name and runs the `jcmd` command.
+
+    You can specify the display name for a target VM through the [`com.ibm.tools.attach.displayName`](dcomibmtoolsattachdisplayname.md) system property. If the display name is not set through the system property, then the main class name along with the application arguments is set as the default display name.
+
+    If you specify `0`, the `jcmd` command is sent to all Java processes that are detected by the current `jcmd` command.
 
 - The available `arguments` are:
 
@@ -59,9 +66,13 @@ The tool uses the Attach API, and has the following limitations:
 
 - Displays information only for local processes that are owned by the current user, due to security considerations.
 - Displays information for OpenJ9 Java processes only
-- Does not show information for processes whose Attach API is disabled. :fontawesome-solid-pencil:{: .note aria-hidden="true"} **Note:** The Attach API is disabled by default on z/OS.
+- Does not show information for processes whose Attach API is disabled. :fontawesome-solid-pencil:{: .note aria-hidden="true"} **Note:** The Attached API is disabled by default on z/OS.
 
-For more information about the Attach API, including how to enable and secure it, see [Java Attach API](attachapi.md).
+For more information about the Attached API, including how to enable and secure it, see [Java Attach API](attachapi.md).
+
+## See Also
+
+-  [What's new in version 0.44.0](version0.44.md#vmid-query-in-the-jcmd-tool-enhanced)
 
 
 <!-- ==== END OF TOPIC ==== tool_jcmd.md ==== -->

--- a/docs/tool_migration.md
+++ b/docs/tool_migration.md
@@ -33,8 +33,6 @@ Runs diagnostic commands on a specified VM. The main difference from the HotSpot
 
 - The `-f` option to read commands from a file.
 - The `Perfcounter.print` option for displaying performance counters for the target VM.
-- Selecting VMs by main class instead of VMID.
-- Specifying `0` as a VMID to target all VMs.
 
 #### Java memory map tool (`jmap`)
 

--- a/docs/version0.44.md
+++ b/docs/version0.44.md
@@ -30,6 +30,7 @@ The following new features and notable changes since version 0.43.0 are included
 - ![Start of content that applies to Java 21 (LTS)](cr/java21.png) [Display of multiple warnings on loading the same agent restricted on AIX&reg; systems](#display-of-multiple-warnings-on-loading-the-same-agent-restricted-on-aix-systems) ![End of content that applies to Java 21 (LTS)](cr/java_close_lts.png)
 - [XL C++ Runtime 16.1.0.7 or later required for AIX OpenJ9 builds on OpenJDK 8](#xl-c-runtime-16107-or-later-required-for-aix-openj9-builds-on-openjdk-8)
 - [New `-XX:[+|-]ShowUnmountedThreadStacks` option added](#new-xx-showunmountedthreadstacks-option-added)
+- [VMID query in the `jcmd` tool enhanced](#vmid-query-in-the-jcmd-tool-enhanced)
 
 ## Features and changes
 
@@ -64,6 +65,16 @@ Java&trade; core file lists stacks of only those threads that are mapped to plat
 You can use the `-XX:+ShowUnmountedThreadStacks` option to include all the thread data that a VM is aware of, both regular Java threads and the unmounted virtual threads, in a Java core file.
 
 For more information, see [` -XX:[+|-]ShowUnmountedThreadStacks`](xxshowunmountedthreadstacks.md). ![End of content that applies to Java 21 (LTS)](cr/java_close_lts.png)
+
+### VMID query in the `jcmd` tool enhanced
+
+Earlier in OpenJ9, when sending a `jcmd` command to a VM, you had to run `jcmd -l` to retrieve all the pids for all the VMs found on the machine. Then, you had to use `jcmd [vmid] [command]` to send the command to the specific VM.
+
+For OpenJDK compatibility, OpenJ9 now supports direct use of the Java process name, full or partial, as the ID to send the `jcmd` command.
+
+The `jcmd` tool also now supports specifying `0` as a VMID to target all VMs.
+
+For more information, see [Java diagnostic command (`jcmd`) tool](tool_jcmd.md).
 
 ## Known problems and full release information
 


### PR DESCRIPTION
https://github.com/eclipse-openj9/openj9-docs/issues/1292

Updated the related topics with the change in jcmd VMID query behavior

Closes #1292
Signed-off-by: Sreekala Gopakumar <sreekala.gopakumar@ibm.com>