### PR TITLE
Persistent shared caches are supported on z/OS

### DIFF
--- a/docs/shrc.md
+++ b/docs/shrc.md
@@ -79,7 +79,7 @@ A shared classes cache can be *persistent* or *non-persistent* according to the 
 - persistent caches are written to memory-mapped files and remain in place, even after a system is rebooted.
 - non-persistent caches exist in shared memory and are automatically removed when the operating system is restarted.
 
-By default, a shared classes cache is persistent, except on the z/OS&reg; platform, where persistent caches are not supported.
+By default, a shared classes cache is persistent, except on the z/OS platform.
 If you are using a non-persistent cache, you can use a cache utility to create a snapshot of the cache, which can be reinitialized after a reboot. For more information see [Saving a non-persistent shared classes cache](#saving-a-non-persistent-shared-classes-cache).
 
 If you have multiple VMs and you do not change the default shared classes behavior, the VMs share a single default cache, assuming that the VMs are from a single Java installation. If the VMs are from different Java installations, the cache might be deleted and re-created.
@@ -220,10 +220,7 @@ The [`-Xshareclasses:listAllCaches`](xshareclasses.md#listallcaches) cache utili
 
 A snapshot can be created only if the user has sufficient permissions to create the destination snapshot file. If a snapshot of the same name exists already, it is overwritten. On platforms that support persistent caches, the `nonpersistent` suboption must be specified in order to create a snapshot. For information about removing snapshot files, see the `destroySnapshot` and `destroyAllSnapshots` cache utilities in [Housekeeping](#housekeeping).
 
-:fontawesome-solid-pencil:{: .note aria-hidden="true"} **Notes:**
-
-- Persistent caches are not supported on z/OS.
-- The `snapshotCache` and `restoreFromCache` cache utilities cannot be used on Windows systems.
+:fontawesome-solid-pencil:{: .note aria-hidden="true"} **Note:** The `snapshotCache` and `restoreFromCache` cache utilities cannot be used on Windows systems.
 
 ## Housekeeping
 

--- a/docs/xscmx.md
+++ b/docs/xscmx.md
@@ -71,7 +71,6 @@ Non-persistent caches are stored in shared memory and are removed when a system 
 
 :fontawesome-solid-pencil:{: .note aria-hidden="true"} **Note:** By default, a cache is persistent on all platforms, except z/OS.
 
-
 ## See also
 
 - [`-Xscdmx`](xscdmx.md) (control the size of the class debug area)

--- a/docs/xshareclasses.md
+++ b/docs/xshareclasses.md
@@ -96,7 +96,7 @@ When you specify `-Xshareclasses` without any parameters and without specifying 
     - On z/OS&reg; systems, `<directory>` is the `/tmp/javasharedresources` directory.
     - On other operating systems, `<directory>` is `.cache/javasharedresources` in the user's home directory, unless the `groupAccess` parameter is specified, in which case it is `/tmp/javasharedresources`, because some members of the group might not have access to the user's home directory. You must have sufficient permissions in `<directory>`. Do not set user's home directory on a NFS or shared mount.
 
-: On AIX&reg;, Linux, macOS, and Windows systems, the VM writes persistent cache files directly into the directory specified. Persistent cache files can be safely moved and deleted from the file system.
+: On all operating systems, the VM writes persistent cache files directly into the directory specified. Persistent cache files can be safely moved and deleted from the file system.
 
 : Non-persistent caches are stored in shared memory and have control files that describe the location of the memory. Control files are stored in a `javasharedresources` subdirectory of the `cacheDir` specified. Do not move or delete control files in this directory. The `listAllCaches` utility, the `destroyAll` utility, and the `expire` suboption work only in the scope of a given `cacheDir`.
 
@@ -134,7 +134,7 @@ When you specify `-Xshareclasses` without any parameters and without specifying 
 | The cache directory is a new directory and you do not specify the `groupAccess` suboption | 0700 |
 | The cache directory already exists and is not `<HomeDir>/.cache/javasharedresources` | Unchanged |
 
-: †On z/OS&reg; systems, permissions for existing cache directories are unchanged, to avoid generating RACF&reg; errors, which generate log messages.
+: †On z/OS systems, permissions for existing cache directories are unchanged, to avoid generating RACF&reg; errors, which generate log messages.
 
 : :fontawesome-solid-pencil:{: .note aria-hidden="true"} **Note:** It is good practice to explicitly set permissions for the cache directory when the defaults are not appropriate. See [Class data sharing: Best practices for using `-Xshareclasses`](shrc.md#best-practices-for-using-xshareclasses).
 
@@ -435,7 +435,7 @@ behavior, which can improve the performance of class loading from the shared cla
 
         -Xshareclasses:persistent
 
-:   Uses a persistent cache. The cache is created on disk, which persists beyond operating system restarts. Non-persistent and persistent caches can have the same name. On AIX, you must always use the `persistent` suboption when you run utilities such as `destroy` on a persistent cache.
+:   Uses a persistent cache. The cache is created on disk, which persists beyond operating system restarts. Non-persistent and persistent caches can have the same name. On z/OS, you must always use the `persistent` suboption when you run utilities such as `destroy` on a persistent cache.
 
 :   :fontawesome-solid-pencil:{: .note aria-hidden="true"} **Notes:**
 


### PR DESCRIPTION
https://github.com/eclipse-openj9/openj9-docs/issues/1298

Added z/OS in list of platforms that support persistent shared cache

Closes #1298
Signed-off-by: Sreekala Gopakumar <sreekala.gopakumar@ibm.com>