### PR TITLE
Document -Dcom.ibm.tools.attach.fileAccessUpdateTime system property

### DIFF
--- a/docs/dcomibmtoolsattachfileaccessupdatetime.md
+++ b/docs/dcomibmtoolsattachfileaccessupdatetime.md
@@ -1,0 +1,54 @@
+<!--
+* Copyright (c) 2017, 2024 IBM Corp. and others
+*
+* This program and the accompanying materials are made
+* available under the terms of the Eclipse Public License 2.0
+* which accompanies this distribution and is available at
+* https://www.eclipse.org/legal/epl-2.0/ or the Apache
+* License, Version 2.0 which accompanies this distribution and
+* is available at https://www.apache.org/licenses/LICENSE-2.0.
+*
+* This Source Code may also be made available under the
+* following Secondary Licenses when the conditions for such
+* availability set forth in the Eclipse Public License, v. 2.0
+* are satisfied: GNU General Public License, version 2 with
+* the GNU Classpath Exception [1] and GNU General Public
+* License, version 2 with the OpenJDK Assembly Exception [2].
+*
+* [1] https://www.gnu.org/software/classpath/license.html
+* [2] https://openjdk.org/legal/assembly-exception.html
+*
+* SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0 OR GPL-2.0-only WITH OpenJDK-assembly-exception-1.0
+-->
+
+# -Dcom.ibm.tools.attach.fileAccessUpdateTime
+
+**Linux&reg; only**
+
+This option enables Attach API to update the control file access times at specific intervals, for long-running applications.
+
+## Syntax
+
+        -Dcom.ibm.tools.attach.fileAccessUpdateTime=<sleep days>
+
+where `<sleep days>` is the number of interval days after which Attach API updates the control file access times for long-running applications. The default value for `<sleep days>` is 8.
+
+## Explanation
+
+By default, the Attach API of a VM places its control files in the system temporary directory, `/tmp/.com_ibm_tools_attach`. The long-running Attach API uses the control files to operate. But, the VM does not open, modify, or read from these files after the files are created, if there is no attempt to attach to a target VM.
+
+This causes a problem in Linux environments because by default `systemd-tmpfiles` automatically deletes all files and directories that are stored in the `/tmp/` folder that are not changed or read within a specific time period. By default, the files in the `/tmp/` folder are cleaned up after 10 days by `systemd-tmpfiles`.
+
+You can prevent Linux `systemd-tmpfiles` from deleting the Attach API control files within the `/tmp/` folder with the `-Dcom.ibm.tools.attach.fileAccessUpdateTime` system property. You can specify the interval days after which Attach API updates the control file access times with the `-Dcom.ibm.tools.attach.fileAccessUpdateTime` system property.
+
+If `0` is specified as the number of `<sleep days>`, the control file access times are not updated and if `systemd-tmpfiles` is enabled, it deletes the files in the `/tmp/` folder.
+
+You can specify a different location outside of the `/tmp/` folder to place the Attach API control files with the [`-Dcom.ibm.tools.attach.directory`](dcomibmtoolsattachdirectory.md) system property, if you do not want to use the `-Dcom.ibm.tools.attach.fileAccessUpdateTime` system property.
+
+## See also
+
+- [Java&trade; Attach API](attachapi.md)
+- [What's new in version 0.44.0](version0.44.md#new-system-property-added-to-prevent-the-deletion-of-the-attach-api-control-files-within-the-tmp-folder)
+
+
+<!-- ==== END OF TOPIC ==== dcomibmtoolsattachfileaccessupdatetime.md ==== -->

--- a/docs/version0.44.md
+++ b/docs/version0.44.md
@@ -32,6 +32,7 @@ The following new features and notable changes since version 0.43.0 are included
 - [New `-XX:[+|-]ShowUnmountedThreadStacks` option added](#new-xx-showunmountedthreadstacks-option-added)
 - [VMID query in the `jcmd` tool enhanced](#vmid-query-in-the-jcmd-tool-enhanced)
 - [DDR field names in `J9BuildFlags` changed](#ddr-field-names-in-j9buildflags-changed)
+- [New system property added to prevent the deletion of the Attach API control files within the `/tmp/` folder](#new-system-property-added-to-prevent-the-deletion-of-the-attach-api-control-files-within-the-tmp-folder)
 
 ## Features and changes
 
@@ -87,6 +88,12 @@ The names of `J9BuildFlags` fields changed over time and therefore, supporting s
 Earlier, field names in `J9BuildFlags` were based on names defined in `j9.flags`. Now, when the `J9BuildFlags` is generated for each build, the flag names are those names that are specified in `j9cfg.h` (derived from `j9cfg.h.ftl` or `j9cfg.h.in`) instead of the names that are defined in `j9.flags`. For example, `env_data64` is now referred to as `J9VM_ENV_DATA64`.
 
 You can extend the DDR code, adding your own commands, by writing plug-ins. If the user plug-in code contains references to fields of `J9BuildFlags` to read the build flags in the system dump data, you must change references to use the names as specified in `j9cfg.h`.
+
+### New system property added to prevent the deletion of the Attach API control files within the `/tmp/` folder
+
+You can use the `-Dcom.ibm.tools.attach.fileAccessUpdateTime` system property to prevent Linux&reg; `systemd-tmpfiles` from deleting the Attach API control files within the `/tmp/` folder. By updating the Attach API control file access times to avoid deletion by `systemd-tmpfiles`, the long-running Attach API can continue to use the control files to operate. This system property enables Attach API to update the control file access times at specific intervals.
+
+For more information, see [`-Dcom.ibm.tools.attach.fileAccessUpdateTime`](dcomibmtoolsattachfileaccessupdatetime.md).
 
 ## Known problems and full release information
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -244,6 +244,7 @@ nav:
             - "-Dcom.ibm.tools.attach.directory"                                 : dcomibmtoolsattachdirectory.md
             - "-Dcom.ibm.tools.attach.displayName"                               : dcomibmtoolsattachdisplayname.md
             - "-Dcom.ibm.tools.attach.enable"                                    : dcomibmtoolsattachenable.md
+            - "-Dcom.ibm.tools.attach.fileAccessUpdateTime"                      : dcomibmtoolsattachfileaccessupdatetime.md
             - "-Dcom.ibm.tools.attach.id"                                        : dcomibmtoolsattachid.md
             - "-Dcom.ibm.tools.attach.logging"                                   : dcomibmtoolsattachlogging.md
             - "-Dcom.ibm.tools.attach.log.name"                                  : dcomibmtoolsattachlogname.md


### PR DESCRIPTION
https://github.com/eclipse-openj9/openj9-docs/issues/1310

Created a new topic for the -Dcom.ibm.tools.attach.fileAccessUpdateTime system property. Updated the What's new in 0.44.0 version

Closes #1310
Signed-off-by: Sreekala Gopakumar sreekala.gopakumar@ibm.com