### PR TITLE
OpenSSL MD5 message digest acceleration

### DIFF
--- a/docs/djdknativecrypto.md
+++ b/docs/djdknativecrypto.md
@@ -37,11 +37,33 @@ This option controls the use of OpenSSL native cryptographic support.
 
 ## Explanation
 
-OpenSSL support is enabled by default for the Digest, CBC, GCM, RSA, ChaCha20 and ChaCha20-Poly1305, ECDH key agreement, EC key generation, XDH key agreement, and XDH key generation algorithms. If you want to turn off the OpenSSL implementation, set this option to `false`.
+OpenSSL support is enabled by default for the following algorithms:
 
+- CBC
+- ChaCha20 and ChaCha20-Poly1305
+- EC key generation
+- ECDH key agreement
+- GCM
+- MD5
+- RSA
+- SHA-224
+- SHA-256
+- SHA-384
+- SHA-512
+- XDH key agreement
+- XDH key generation
 
-:fontawesome-solid-triangle-exclamation:{: .warn aria-hidden="true"} **Restriction:**  ![Start of content that applies to Java 8 (LTS)](cr/java8.png) The ChaCha20 and ChaCha20-Poly1305 algorithms are not supported on Java&trade; 8. The XDH key agreement and XDH key generation algorithms also are not supported on Java 8. ![End of content that applies only to Java 8 (LTS)](cr/java_close_lts.png)
+If you want to turn off the OpenSSL implementation, set the `-Djdk.nativeCrypto` option to `false`.
 
+:fontawesome-solid-triangle-exclamation:{: .warn aria-hidden="true"} **Restrictions:**
+
+- ![Start of content that applies to Java 8 (LTS)](cr/java8.png) The ChaCha20 and ChaCha20-Poly1305 algorithms are not supported on Java&trade; 8. The XDH key agreement and XDH key generation algorithms also are not supported on Java 8. ![End of content that applies only to Java 8 (LTS)](cr/java_close_lts.png)
+- OpenSSL native cryptographic support is not available for the following algorithms on AIX&reg;:
+
+    - EC key generation (`-Djdk.nativeECKeyGen`)
+    - MD5 (part of `-Djdk.nativeDigest`)
+    - XDH key generation (`-Djdk.nativeXDHKeyGen`)
+    - XDH key agreement (`-Djdk.nativeXDHKeyAgreement`)
 
 If you want to turn off the algorithms individually, use the following system properties:
 

--- a/docs/djdknativedigest.md
+++ b/docs/djdknativedigest.md
@@ -23,7 +23,7 @@
 
 # -Djdk.nativeDigest
 
-This option enables or disables OpenSSL native cryptographic support for the Digest algorithm.
+This option enables or disables OpenSSL native cryptographic support for the MD5, SHA-224, SHA-256, SHA-384, and SHA-512 digest algorithms.
 
 ## Syntax
 
@@ -38,7 +38,9 @@ This option enables or disables OpenSSL native cryptographic support for the Dig
 
 <!--OpenSSL support is enabled by default for the Digest algorithm. If you want to turn off this algorithm only, set this option to `false`.-->
 
- To turn off all the algorithms, see the [-Djdk.nativeCrypto](djdknativecrypto.md) system property command line option.
+ To turn off all the algorithms, see the [-Djdk.nativeCrypto](djdknativecrypto.md) system property command-line option.
+
+ :fontawesome-solid-pencil:{: .note aria-hidden="true"} **Note:** The MD5 digest algorithm is not supported for OpenSSL on AIX&reg;. The Java implementation is always used for the MD5 digest algorithm on AIX.
 
 
 

--- a/docs/djdknativeeckeygen.md
+++ b/docs/djdknativeeckeygen.md
@@ -39,6 +39,8 @@ This option enables or disables OpenSSL native cryptographic support for the EC 
 
 OpenSSL support is enabled by default for the EC key generation algorithm. If you want to turn off support for this algorithm only, set this option to `false`. To turn off support for this and other algorithms, see the [`-Djdk.nativeCrypto`](djdknativecrypto.md) system property command line option.
 
+:fontawesome-solid-pencil:{: .note aria-hidden="true"} **Note:** The EC key generation algorithm is not supported for OpenSSL on AIX&reg;. This option is ignored on AIX and the Java implementation is always used.
+
 
 
 

--- a/docs/djdknativexdhkeyagreement.md
+++ b/docs/djdknativexdhkeyagreement.md
@@ -45,6 +45,7 @@
 
 OpenSSL support is enabled by default for the XDH key agreement algorithm. If you want to turn off support for this algorithm only, set this option to `false`. To turn off support for this and other algorithms, see the [`-Djdk.nativeCrypto`](djdknativecrypto.md) system property command line option.
 
+:fontawesome-solid-pencil:{: .note aria-hidden="true"} **Note:** The XDH key agreement algorithm is not supported for OpenSSL on AIX&reg;. This option is ignored on AIX and the Java implementation is always used.
 
 
 

--- a/docs/djdknativexdhkeygen.md
+++ b/docs/djdknativexdhkeygen.md
@@ -45,6 +45,8 @@
 
 OpenSSL support is enabled by default for the XDH key generation algorithm. If you want to turn off support for this algorithm only, set this option to `false`. To turn off support for this and other algorithms, see the [`-Djdk.nativeCrypto`](djdknativecrypto.md) system property command line option.
 
+:fontawesome-solid-pencil:{: .note aria-hidden="true"} **Note:** The XDH key generation algorithm is not supported for OpenSSL on AIX&reg;. This option is ignored on AIX and the Java implementation is always used.
+
 
 
 

--- a/docs/version0.46.md
+++ b/docs/version0.46.md
@@ -1,0 +1,47 @@
+<!--
+* Copyright (c) 2017, 2024 IBM Corp. and others
+*
+* This program and the accompanying materials are made
+* available under the terms of the Eclipse Public License 2.0
+* which accompanies this distribution and is available at
+* https://www.eclipse.org/legal/epl-2.0/ or the Apache
+* License, Version 2.0 which accompanies this distribution and
+* is available at https://www.apache.org/licenses/LICENSE-2.0.
+*
+* This Source Code may also be made available under the
+* following Secondary Licenses when the conditions for such
+* availability set forth in the Eclipse Public License, v. 2.0
+* are satisfied: GNU General Public License, version 2 with
+* the GNU Classpath Exception [1] and GNU General Public
+* License, version 2 with the OpenJDK Assembly Exception [2].
+*
+* [1] https://www.gnu.org/software/classpath/license.html
+* [2] https://openjdk.org/legal/assembly-exception.html
+*
+* SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0 OR GPL-2.0-only WITH OpenJDK-assembly-exception-1.0
+-->
+
+# What's new in version 0.46.0
+
+The following new features and notable changes since version 0.45.0 are included in this release:
+
+- [New binaries and changes to supported environments](#binaries-and-supported-environments)
+- [MD5 message digest algorithm support for OpenSSL](#md5-message-digest-algorithm-support-for-openssl)
+
+## Features and changes
+
+### Binaries and supported environments
+
+Eclipse OpenJ9&trade; release 0.46.0 supports OpenJDK 8, 11, 17, 21, and 22.
+
+To learn more about support for OpenJ9 releases, including OpenJDK levels and platform support, see [Supported environments](openj9_support.md).
+
+### MD5 message digest algorithm support for OpenSSL
+
+OpenSSL native cryptographic support is added for the MD5 message digest algorithm, providing improved cryptographic performance. OpenSSL support is enabled by default. If you want to turn off support for the MD5 message digest algorithm, set the [`-Djdk.nativedigest`](djdknativedigest.md) system property to `false`.
+
+## Known problems and full release information
+
+To see known problems and a complete list of changes between Eclipse OpenJ9 v0.45.0 and v0.46.0 releases, see the [Release notes](https://github.com/eclipse-openj9/openj9/blob/master/doc/release-notes/0.46/0.46.md).
+
+<!-- ==== END OF TOPIC ==== version0.46.md ==== -->

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -101,6 +101,7 @@ nav:
 
     - "Release notes" :
         - "Overview"                                                             : openj9_releases.md
+        - "Version 0.46.0"                                                       : version0.46.md
         - "Version 0.45.0"                                                       : version0.45.md
         - "Version 0.44.0"                                                       : version0.44.md
         - "Version 0.43.0"                                                       : version0.43.md


### PR DESCRIPTION
https://github.com/eclipse-openj9/openj9-docs/issues/1322

Acceleration is added for MD5 message digest and the related topics are updated.

Closes #1322
Signed-off-by: Sreekala Gopakumar <sreekala.gopakumar@ibm.com>