### PR TITLE
New system property -Dcom.ibm.tools.attach.retry

### DIFF
--- a/docs/attachapi.md
+++ b/docs/attachapi.md
@@ -41,7 +41,7 @@ authorized users or processes can use it. Disable the Attach API if you do not i
 
 If you do not want to disable the Attach API but want to control the unauthorized dynamic loading of agents into the VM by using the Attach API, use the [`-XX:-EnableDynamicAgentLoading`](xxenabledynamicagentloading.md) option.
 
-On Windows systems, the Attach API uses the system temporary directory, which is typically `C:\Users\<USERNAME>\AppData\Local\Temp`.
+On Windows&trade; systems, the Attach API uses the system temporary directory, which is typically `C:\Users\<USERNAME>\AppData\Local\Temp`.
 The Attach API creates a common subdirectory, which is `.com_ibm_tools_attach` by default. Because files and directories in the system temporary directory are handled by Windows security, only the process owner can connect to their processes.
 
 On UNIX systems, the Attach API uses `/tmp` and creates a common subdirectory, which is `.com_ibm_tools_attach` by default. The common subdirectory must be on a local drive, not a network drive. Security is handled by POSIX file permissions. The Attach API directory must be owned by `root` user and must have read, write, and execute file permissions for `user`, `group`, and `other` (`drwxrwxrwx`). The sticky bit is set so that only the owner and `root` can delete or rename files or directories within it. A process that uses the Java Attach API must be owned by the same UNIX user ID as the target process.
@@ -97,6 +97,7 @@ A number of system properties are available to configure the Attach API when you
 | [`-Dcom.ibm.tools.attach.timeout=<value_in_milliseconds>`](dcomibmtoolsattachtimeout.md)                    | Change the connection timeout                                            |
 | [`-Dcom.ibm.tools.attach.shutdown_timeout=<value_in_milliseconds>`](dcomibmtoolsattachshutdown_timeout.md)  | Specify the timeout for ending the Attach API wait loop thread           |
 | [`-Dcom.ibm.tools.attach.command_timeout=<value_in_milliseconds>`](dcomibmtoolsattachcommand_timeout.md)    | Specify the timeout for sending a command to the target VM after initial attachment   |
+| [`-Dcom.ibm.tools.attach.retry=<number_of_retries>`](dcomibmtoolsattachretry.md)    | Specify the number of times the `jcmd` tool retries attaching to a running VM when the tool encounters the `SocketException` error on Windows platform    |
 
 
 To learn more about each property, click the link in the table.
@@ -110,6 +111,7 @@ Problems with the Attach API generate one of the following exceptions:
 - `com.sun.tools.attach.AgentNotSupportedException`
 - `com.sun.tools.attach.AttachOperationFailedException`
 - `java.io.IOException`
+- `java.net.SocketException`
 
 Exceptions from agents on the target VM go to `stderr` or `stdout` for the target VM. These exceptions are not reported in the output of the attaching VM.
 

--- a/docs/dcomibmtoolsattachretry.md
+++ b/docs/dcomibmtoolsattachretry.md
@@ -1,0 +1,46 @@
+<!--
+* Copyright (c) 2017, 2024 IBM Corp. and others
+*
+* This program and the accompanying materials are made
+* available under the terms of the Eclipse Public License 2.0
+* which accompanies this distribution and is available at
+* https://www.eclipse.org/legal/epl-2.0/ or the Apache
+* License, Version 2.0 which accompanies this distribution and
+* is available at https://www.apache.org/licenses/LICENSE-2.0.
+*
+* This Source Code may also be made available under the
+* following Secondary Licenses when the conditions for such
+* availability set forth in the Eclipse Public License, v. 2.0
+* are satisfied: GNU General Public License, version 2 with
+* the GNU Classpath Exception [1] and GNU General Public
+* License, version 2 with the OpenJDK Assembly Exception [2].
+*
+* [1] https://www.gnu.org/software/classpath/license.html
+* [2] https://openjdk.org/legal/assembly-exception.html
+*
+* SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0 OR GPL-2.0-only WITH OpenJDK-assembly-exception-1.0
+-->
+
+# -Dcom.ibm.tools.attach.retry
+
+**Windows&trade; only**
+
+This option specifies the number of times the `jcmd` tool retries attaching to a running VM when the tool encounters the `SocketException` error.
+
+## Syntax
+
+        -Dcom.ibm.tools.attach.retry=<number_of_retries>
+
+The default value for `<number_of_retries>` is 3.
+
+## Explanation
+
+When the `jcmd` tool sends a command to a running VM, the command might throw the `Socket Exception` error in case of issues, such as a network failure or a connection reset. Instead of failing the attaching request, you can specify the number of times the tool retries attaching to the target VM with the `-Dcom.ibm.tools.attach.retry` system property.
+
+## See also
+
+- [Java&trade; Attach API](attachapi.md)
+- [What's new in version 0.46.0](version0.46.md#new-system-property-added-to-improve-jcmd-attaching-in-case-of-the-socketexception-error-on-windows-platform)
+
+
+<!-- ==== END OF TOPIC ==== dcomibmtoolsattachretry.md ==== -->

--- a/docs/version0.46.md
+++ b/docs/version0.46.md
@@ -30,6 +30,7 @@ The following new features and notable changes since version 0.45.0 are included
 - [Support added for the `com.sun.management.ThreadMXBean.getTotalThreadAllocatedBytes()` API](#support-added-for-the-comsunmanagementthreadmxbeangettotalthreadallocatedbytes-api)
 - [The JITServer AOT caching feature enabled by default at the JITServer server](#the-jitserver-aot-caching-feature-enabled-by-default-at-the-jitserver-server)
 - [New `-XX:[+|-]EnableExtendedHCR` option added](#new-xx-enableextendedhcr-option-added)
+- [New system property added to improve `jcmd` attaching in case of the `SocketException` error on Windows&trade; platform](#new-system-property-added-to-improve-jcmd-attaching-in-case-of-the-socketexception-error-on-windows-platform)
 
 ## Features and changes
 
@@ -66,6 +67,10 @@ For more information, see [ `-XX:[+|-]JITServerUseAOTCache`](xxjitserveruseaotca
 By default, the extended Hot Code Replace (HCR) capability in the VM is disabled for all OpenJDK versions. You can enable or disable the HCR capability by using the [`-XX:[+|-]EnableExtendedHCR`](xxenableextendedhcr.md) option.
 
 The extended HCR feature is deprecated in this release and will be removed in a future release. From OpenJDK 25 onwards, extended HCR will not be supported. Following that, the extended HCR support will be removed from other earlier OpenJDK versions also.
+
+### New system property added to improve `jcmd` attaching in case of the `SocketException` error on Windows platform
+
+When the `jcmd` tool sends a command to a running VM, the command might throw the `Socket Exception` error on Windows platform. Instead of failing the attaching request, you can specify the number of times the tool retries attaching to the target VM with the new system property, [`-Dcom.ibm.tools.attach.retry`](dcomibmtoolsattachretry.md).
 
 ## Known problems and full release information
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -250,6 +250,7 @@ nav:
             - "-Dcom.ibm.tools.attach.id"                                        : dcomibmtoolsattachid.md
             - "-Dcom.ibm.tools.attach.logging"                                   : dcomibmtoolsattachlogging.md
             - "-Dcom.ibm.tools.attach.log.name"                                  : dcomibmtoolsattachlogname.md
+            - "-Dcom.ibm.tools.attach.retry"                                     : dcomibmtoolsattachretry.md
             - "-Dcom.ibm.tools.attach.shutdown_timeout"                          : dcomibmtoolsattachshutdown_timeout.md
             - "-Dcom.ibm.tools.attach.timeout"                                   : dcomibmtoolsattachtimeout.md
             - "-Dfile.encoding"                                                  : dfileencoding.md


### PR DESCRIPTION
https://github.com/eclipse-openj9/openj9-docs/issues/1313

Added the new system property -Dcom.ibm.tools.attach.retry. Updated related topics.

Closes #1313
Signed-off-by: Sreekala Gopakumar sreekala.gopakumar@ibm.com