### PR TITLE
Python-dateutil update

### DIFF
--- a/buildenv/requirements.txt
+++ b/buildenv/requirements.txt
@@ -79,7 +79,7 @@ pygments==2.16.1
     # via mkdocs-material
 pymdown-extensions==10.3
     # via mkdocs-material
-python-dateutil==2.8.2
+python-dateutil==2.9.0
     # via
     #   ghp-import
     #   mkdocs-macros-plugin


### PR DESCRIPTION
mkdocs build is failing because ibm-cos-sdk-core 2.13.6 requires python-dateutil<3.0.0,>=2.9.0, but the current python-dateutil is 2.8.2 which is incompatible.

Signed-off-by: Sreekala Gopakumar sreekala.gopakumar@ibm.com