### PR TITLE
New option to store classes from all class loaders

### DIFF
--- a/docs/version0.46.md
+++ b/docs/version0.46.md
@@ -32,6 +32,7 @@ The following new features and notable changes since version 0.45.0 are included
 - [The extended Hot Code Replace (HCR) capability disabled and `-XX:[+|-]EnableExtendedHCR` option added](#the-extended-hot-code-replace-hcr-capability-disabled-and-xx-enableextendedhcr-option-added)
 - [New system property added to improve `jcmd` attaching in case of the `SocketException` error on Windows&trade; platform](#new-system-property-added-to-improve-jcmd-attaching-in-case-of-the-socketexception-error-on-windows-platform)
 - [`-Xtgc:allocation` report includes core allocation cache statistics per thread](#-xtgcallocation-report-includes-core-allocation-cache-statistics-per-thread)
+- [New `-XX:[+|-]ShareOrphans` option added](#new-xx-shareorphans-option-added)
 
 ## Features and changes
 
@@ -76,6 +77,14 @@ When the `jcmd` tool sends a command to a running VM, the command might throw th
 ### `-Xtgc:allocation` report includes core allocation cache statistics per thread
 
 The [`-Xtgc:allocation`](xtgc.md#allocation) option prints thread-specific allocation cache (TLH) statistics in addition to the cumulative allocation statistics.
+
+### New `-XX:[+|-]ShareOrphans` option added
+
+When `-Xshareclasses` was specified, only those class loaders that implemented the OpenJ9's public shared classes cache APIs (and its child class loaders) could store classes to the shared classes cache. Custom class loaders that did not implement these cache APIs cannot pass the module or class path information to the VM. Classes of such class loaders were not stored to the cache.
+
+You can enable class sharing from all class loaders, irrespective of whether the class loader implements the shared classes cache API, with the `-XX:+ShareOrphans` option.
+
+For more information, see [`-XX:[+|-]ShareOrphans`](xxshareorphans.md).
 
 ## Known problems and full release information
 

--- a/docs/xxshareorphans.md
+++ b/docs/xxshareorphans.md
@@ -1,0 +1,65 @@
+﻿<!--
+* Copyright (c) 2017, 2024 IBM Corp. and others
+*
+* This program and the accompanying materials are made
+* available under the terms of the Eclipse Public License 2.0
+* which accompanies this distribution and is available at
+* https://www.eclipse.org/legal/epl-2.0/ or the Apache
+* License, Version 2.0 which accompanies this distribution and
+* is available at https://www.apache.org/licenses/LICENSE-2.0.
+*
+* This Source Code may also be made available under the
+* following Secondary Licenses when the conditions for such
+* availability set forth in the Eclipse Public License, v. 2.0
+* are satisfied: GNU General Public License, version 2 with
+* the GNU Classpath Exception [1] and GNU General Public
+* License, version 2 with the OpenJDK Assembly Exception [2].
+*
+* [1] https://www.gnu.org/software/classpath/license.html
+* [2] https://openjdk.org/legal/assembly-exception.html
+*
+* SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0 OR GPL-2.0-only WITH OpenJDK-assembly-exception-1.0
+-->
+
+# -XX:[+|-]ShareOrphans
+
+This option enables or disables sharing of orphan classes from class loaders that do not implement the OpenJ9's [public shared classes cache APIs](https://eclipse.dev/openj9/docs/api-shrc/).
+
+## Syntax
+
+        -XX:[+|-]ShareOrphans
+
+| Setting               | Effect  | Default                                                                            |
+|-----------------------|---------|:----------------------------------------------------------------------------------:|
+| `-XX:+ShareOrphans` |  Enable   |                                                                                    |
+| `-XX:-ShareOrphans` |  Disable  |   :fontawesome-solid-check:{: .yes aria-hidden="true"}<span class="sr-only">yes</span>   |
+
+## Explanation
+
+In the previous versions, OpenJ9 stored only bootstrap classes and hidden classes in the shared classes cache by default, that is the `-Xshareclasses` option is not specified by default. When the `-Xshareclasses` option was specified, only those class loaders that implemented the OpenJ9's public shared classes cache APIs (and its child class loaders) could store classes to the shared classes cache. For classes from custom class loaders that did not implement the shared classes cache APIs, the VM does not have their module or class path information. Such classes were not stored to the cache.
+
+You can enable class sharing from all class loaders, irrespective of whether the class loader implements the cache API, with the `-XX:+ShareOrphans` option. This option automatically enables the `-Xshareclasses` option. When the class sharing from all class loaders is enabled, following is the sharing behavior:
+
+- For classes from class loaders that implement the shared class cache API, they are shared as normal ROM classes, which is same as enabling `-Xshareclasses`.
+
+- For classes from class loaders that do not implement the shared class cache API, the VM won't have their class or module path information. They are shared as orphan ROM classes with other VMs after extra comparisons.
+
+Storing additional classes in the cache makes more classes available for Ahead-of-Time (AOT) compilation and therefore might improve startup performance.
+
+You can disable sharing class as orphans from class loader that does not implement the shared class cache API with the `-XX:-ShareOrphans` option. This option is the default mode.
+
+:fontawesome-solid-triangle-exclamation:{: .warn aria-hidden="true"} **Restrictions:**
+
+- Sharing classes as orphans requires more comparison on the classes by the VM. The comparison itself has a negative performance impact. However, the benefits of more AOT generated for the cached class might offset the negative impact.
+- More cached classes usually result in more AOT-compiled methods. The relative advantage of orphan sharing decreases when the CPUs are less. With more CPUs, the compilation threads can compile those additional methods in parallel with the application threads, while with fewer CPUs, extra compilation activity hinders application threads.
+- The class comparison might not detect the removal of method access modifiers. For example, a change of a method from public to package-private.
+- `java.lang.StackTraceElement.getClassLoaderName()` might return null for classes that are stored in the shared cache.
+
+
+## See also
+
+- [What's new in version 0.46.0](version0.46.md#new-xx-shareorphans-option-added)
+
+
+
+<!-- ==== END OF TOPIC ==== xxshareorphans.md ==== -->

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -467,6 +467,7 @@ nav:
             - "-XX:ShareClassesDisableBCI"                                       : xxshareclassesenablebci.md         #redirect
             - "-XX:ShareClassesEnableBCI"                                        : xxshareclassesenablebci.md
             - "-XX:SharedCacheHardLimit"                                         : xxsharedcachehardlimit.md
+            - "-XX:[+|-]ShareOrphans"                                            : xxshareorphans.md
             - "-XX:[+|-]ShareUnsafeClasses"                                      : xxshareunsafeclasses.md
             - "-XX:[+|-]ShowCarrierFrames"                                       : xxshowcarrierframes.md
             - "-XX:[+|-]ShowCodeDetailsInExceptionMessages"                      : xxshowcodedetailsinexceptionmessages.md


### PR DESCRIPTION
https://github.com/eclipse-openj9/openj9-docs/issues/1330

New option `-XX:[+|-]ShareOrphans` added. Related topics updated.

Closes #1330
Signed-off-by: Sreekala Gopakumar sreekala.gopakumar@ibm.com