### PR TITLE
Updated the requests version in requirements.txt

### DIFF
--- a/buildenv/requirements.txt
+++ b/buildenv/requirements.txt
@@ -94,7 +94,7 @@ pyyaml-env-tag==0.1
     # via mkdocs
 regex==2022.10.31
     # via mkdocs-material
-requests==2.32.0
+requests==2.32.2
     # via mkdocs-material
 six==1.16.0
     # via python-dateutil


### PR DESCRIPTION
Build_mkdocs_for_kc_no_Docker build was failing because of the following errors:

ERROR: pip's dependency resolver does not currently take into account all the packages that are installed. This behaviour is the source of the following dependency conflicts. softlayer 6.2.4 requires requests>=2.32.2, but you have requests 2.32.0 which is incompatible. 

Tried updating to 2.32.3  as per the latest mkdocs dependencies level but encountered the following error:

ERROR: pip's dependency resolver does not currently take into account all the packages that are installed. This behaviour is the source of the following dependency conflicts. ibm-cos-sdk-core 2.13.6 requires requests<2.32.3,>=2.32.0, but you have requests 2.32.3 which is incompatible.

So, updated the requests version to 2.32.2. Tested and the build doesn't fail now.

Signed-off-by: Sreekala Gopakumar sreekala.gopakumar@ibm.com