### PR TITLE
Fix DTFJ example compilation warning on Java > 8

### DIFF
--- a/docs/interface_dtfj.md
+++ b/docs/interface_dtfj.md
@@ -96,8 +96,8 @@ public class DTFJEX1 {
         if (args.length > 0) {
             File f = new File(args[0]);
             try {
-                Class factoryClass = Class.forName("com.ibm.dtfj.image.j9.ImageFactory");
-                ImageFactory factory = (ImageFactory) factoryClass.newInstance();
+                Class<?> factoryClass = Class.forName("com.ibm.dtfj.image.j9.ImageFactory");
+                ImageFactory factory = (ImageFactory) factoryClass.getDeclaredConstructor().newInstance();
                 image = factory.getImage(f);
             } catch (ClassNotFoundException e) {
                 System.err.println("Could not find DTFJ factory class");
@@ -105,7 +105,7 @@ public class DTFJEX1 {
             } catch (IllegalAccessException e) {
                 System.err.println("IllegalAccessException for DTFJ factory class");
                 e.printStackTrace(System.err);
-            } catch (InstantiationException e) {
+            } catch (ReflectiveOperationException e) {
                 System.err.println("Could not instantiate DTFJ factory class");
                 e.printStackTrace(System.err);
             } catch (IOException e) {
@@ -161,8 +161,8 @@ public class DTFJEX2 {
             File javacoreFile = new File(args[0]);
 
             try {
-                Class factoryClass = Class.forName("com.ibm.dtfj.image.javacore.JCImageFactory");
-                ImageFactory factory = (ImageFactory) factoryClass.newInstance();
+                Class<?> factoryClass = Class.forName("com.ibm.dtfj.image.javacore.JCImageFactory");
+                ImageFactory factory = (ImageFactory) factoryClass.getDeclaredConstructor().newInstance();
                 image = factory.getImage(javacoreFile);
             } catch (ClassNotFoundException e) {
                 System.err.println("Could not find DTFJ factory class");
@@ -170,7 +170,7 @@ public class DTFJEX2 {
             } catch (IllegalAccessException e) {
                 System.err.println("IllegalAccessException for DTFJ factory class");
                 e.printStackTrace(System.err);
-            } catch (InstantiationException e) {
+            } catch (ReflectiveOperationException e) {
                 System.err.println("Could not instantiate DTFJ factory class");
                 e.printStackTrace(System.err);
             } catch (IOException e) {
@@ -250,9 +250,9 @@ public class DTFJEX2
          File f = new File( args[0] );
          try
          {
-            Class factoryClass = Class
+            Class<?> factoryClass = Class
                   .forName( "com.ibm.dtfj.image.j9.ImageFactory" );
-            ImageFactory factory = (ImageFactory) factoryClass.newInstance( );
+            ImageFactory factory = (ImageFactory) factoryClass.getDeclaredConstructor().newInstance( );
             image = factory.getImage( f );
          }
          catch ( Exception ex )


### PR DESCRIPTION
Java 9 and above has deprecated Class.newInstance in favor of Class.getDeclaredConstructor().newInstance:

https://docs.oracle.com/javase/9/docs/api/java/lang/Class.html#newInstance--

The DTFJ examples use the old form which causes the following compilation warnings:

```
DTFJVendorCheck.java:55: warning: [deprecation] newInstance() in Class has been deprecated
			ImageFactory factory = (ImageFactory) factoryClass.newInstance();
			                                                  ^
  where T is a type-variable:
    T extends Object declared in class Class

DTFJVendorCheck.java:55: warning: [unchecked] unchecked call to getDeclaredConstructor(Class<?>...) as a member of the raw type Class
			ImageFactory factory = (ImageFactory) factoryClass.getDeclaredConstructor().newInstance();
			                                                                         ^
  where T is a type-variable:
    T extends Object declared in class Class
```

Change the examples to use the new form and parameterize the Class.forName call.

Java 8 supports both updates: https://docs.oracle.com/javase/8/docs/api/java/lang/Class.html