### PR TITLE
-Xshareclasses automatically turns on -XX:+ShareOrphans

### DIFF
--- a/docs/version0.47.md
+++ b/docs/version0.47.md
@@ -1,0 +1,49 @@
+<!--
+* Copyright (c) 2017, 2024 IBM Corp. and others
+*
+* This program and the accompanying materials are made
+* available under the terms of the Eclipse Public License 2.0
+* which accompanies this distribution and is available at
+* https://www.eclipse.org/legal/epl-2.0/ or the Apache
+* License, Version 2.0 which accompanies this distribution and
+* is available at https://www.apache.org/licenses/LICENSE-2.0.
+*
+* This Source Code may also be made available under the
+* following Secondary Licenses when the conditions for such
+* availability set forth in the Eclipse Public License, v. 2.0
+* are satisfied: GNU General Public License, version 2 with
+* the GNU Classpath Exception [1] and GNU General Public
+* License, version 2 with the OpenJDK Assembly Exception [2].
+*
+* [1] https://www.gnu.org/software/classpath/license.html
+* [2] https://openjdk.org/legal/assembly-exception.html
+*
+* SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0 OR GPL-2.0-only WITH OpenJDK-assembly-exception-1.0
+-->
+
+# What's new in version 0.47.0
+
+The following new features and notable changes since version 0.46.0 are included in this release:
+
+- [New binaries and changes to supported environments](#binaries-and-supported-environments)
+- [`-Xshareclasses` option automatically enables `-XX:+ShareOrphans`](#-xshareclasses-option-automatically-enables-xxshareorphans)
+
+## Features and changes
+
+### Binaries and supported environments
+
+Eclipse OpenJ9&trade; release 0.47.0 supports OpenJDK 23.
+
+To learn more about support for OpenJ9 releases, including OpenJDK levels and platform support, see [Supported environments](openj9_support.md).
+
+### `-Xshareclasses` option automatically enables `-XX:+ShareOrphans`
+
+The `-XX:+ShareOrphans` option automatically enables the `-Xshareclasses` option. From release 0.47.0 onwards, if the `-Xshareclasses` option is specified in the command line, it automatically enables the `-XX:+ShareOrphans` option.
+
+For more information, see [`-XX:[+|-]ShareOrphans`](xxshareorphans.md).
+
+## Known problems and full release information
+
+To see known problems and a complete list of changes between Eclipse OpenJ9 v0.46.0 and v0.47.0 releases, see the [Release notes](https://github.com/eclipse-openj9/openj9/blob/master/doc/release-notes/0.47/0.47.md).
+
+<!-- ==== END OF TOPIC ==== version0.47.md ==== -->

--- a/docs/xxshareorphans.md
+++ b/docs/xxshareorphans.md
@@ -38,7 +38,9 @@ This option enables or disables sharing of orphan classes from class loaders tha
 
 In the previous versions, OpenJ9 stored only bootstrap classes and hidden classes in the shared classes cache by default, that is the `-Xshareclasses` option is not specified by default. When the `-Xshareclasses` option was specified, only those class loaders that implemented the OpenJ9's public shared classes cache APIs (and its child class loaders) could store classes to the shared classes cache. For classes from custom class loaders that did not implement the shared classes cache APIs, the VM does not have their module or class path information. Such classes were not stored to the cache.
 
-You can enable class sharing from all class loaders, irrespective of whether the class loader implements the cache API, with the `-XX:+ShareOrphans` option. This option automatically enables the `-Xshareclasses` option. When the class sharing from all class loaders is enabled, following is the sharing behavior:
+You can enable class sharing from all class loaders, irrespective of whether the class loader implements the cache API, with the `-XX:+ShareOrphans` option. This option automatically enables the `-Xshareclasses` option. Conversely, if the `-Xshareclasses` option is specified in the command line, it automatically enables the `-XX:+ShareOrphans` option (from release 0.47.0 onwards).
+
+When the class sharing from all class loaders is enabled, following is the sharing behavior:
 
 - For classes from class loaders that implement the shared class cache API, they are shared as normal ROM classes, which is same as enabling `-Xshareclasses`.
 
@@ -59,6 +61,7 @@ You can disable sharing class as orphans from class loader that does not impleme
 ## See also
 
 - [What's new in version 0.46.0](version0.46.md#new-xx-shareorphans-option-added)
+- [What's new in version 0.47.0](version0.47.md#-xshareclasses-option-automatically-enables-xxshareorphans)
 
 
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -101,6 +101,7 @@ nav:
 
     - "Release notes" :
         - "Overview"                                                             : openj9_releases.md
+        - "Version 0.47.0"                                                       : version0.47.md
         - "Version 0.46.0"                                                       : version0.46.md
         - "Version 0.45.0"                                                       : version0.45.md
         - "Version 0.44.0"                                                       : version0.44.md


### PR DESCRIPTION
https://github.com/eclipse-openj9/openj9-docs/issues/1354

-Xshareclasses now automatically turns on -XX:+ShareOrphans

Closes #1354
Signed-off-by: Sreekala Gopakumar sreekala.gopakumar@ibm.com