### PR TITLE
Restrictions in the `-XX:[+|-]ShareOrphans` option removed

### DIFF
--- a/docs/version0.47.md
+++ b/docs/version0.47.md
@@ -27,6 +27,7 @@ The following new features and notable changes since version 0.46.0 are included
 
 - [New binaries and changes to supported environments](#binaries-and-supported-environments)
 - [`-Xshareclasses` option automatically enables `-XX:+ShareOrphans`](#-xshareclasses-option-automatically-enables-xxshareorphans)
+- [Restrictions in the `-XX:[+|-]ShareOrphans` option fixed](#restrictions-in-the-xx-shareorphans-option-fixed)
 
 ## Features and changes
 
@@ -41,6 +42,15 @@ To learn more about support for OpenJ9 releases, including OpenJDK levels and pl
 The `-XX:+ShareOrphans` option automatically enables the `-Xshareclasses` option. From release 0.47.0 onwards, if the `-Xshareclasses` option is specified in the command line, it automatically enables the `-XX:+ShareOrphans` option.
 
 For more information, see [`-XX:[+|-]ShareOrphans`](xxshareorphans.md).
+
+### Restrictions in the `-XX:[+|-]ShareOrphans` option fixed
+
+The `-XX:[+|-]ShareOrphans` option had the following restrictions:
+
+- The class comparison might not detect the removal of method access modifiers. For example, a change of a method from public to package-private.
+- `java.lang.StackTraceElement.getClassLoaderName()` might return null for classes that are stored in the shared cache.
+
+These restrictions are no longer applicable from this release onwards.
 
 ## Known problems and full release information
 

--- a/docs/xxshareorphans.md
+++ b/docs/xxshareorphans.md
@@ -54,9 +54,8 @@ You can disable sharing class as orphans from class loader that does not impleme
 
 - Sharing classes as orphans requires more comparison on the classes by the VM. The comparison itself has a negative performance impact. However, the benefits of more AOT generated for the cached class might offset the negative impact.
 - More cached classes usually result in more AOT-compiled methods. The relative advantage of orphan sharing decreases when the CPUs are less. With more CPUs, the compilation threads can compile those additional methods in parallel with the application threads, while with fewer CPUs, extra compilation activity hinders application threads.
-- The class comparison might not detect the removal of method access modifiers. For example, a change of a method from public to package-private.
-- `java.lang.StackTraceElement.getClassLoaderName()` might return null for classes that are stored in the shared cache.
 
+For more information, see [What's new in version 0.47.0](version0.47.md#restrictions-in-the-xx-shareorphans-option-fixed).
 
 ## See also
 


### PR DESCRIPTION
Two of the restrictions fixed in 0.47.0 release and therefore removed in the related topic.

Signed-off-by: Sreekala Gopakumar sreekala.gopakumar@ibm.com