### PR TITLE
Fix typo in list of -Xtrace components

### DIFF
--- a/docs/xtrace.md
+++ b/docs/xtrace.md
@@ -260,7 +260,7 @@ The following table lists the possible Java components (`<component>`). To inclu
 | **module**      | VM modularity                                                                  |
 | **mt**          | Java methods (see **Note**)                                                    |
 | **net**         | Class library TCP/IP networking native code                                    |
-| **omrmm         | OMR memory management                                                          |
+| **omrmm**       | OMR memory management                                                          |
 | **omrport**     | OMR port library                                                               |
 | **omrti**       | OMR tooling                                                                    |
 | **omrutil**     | OMR utilities                                                                  |


### PR DESCRIPTION
Related to https://github.com/eclipse-openj9/openj9-docs/pull/1413