### PR TITLE
Revert MkDocs version 1.6.1 to 1.5.3

### DIFF
--- a/buildenv/requirements.txt
+++ b/buildenv/requirements.txt
@@ -54,7 +54,7 @@ mergedeep==1.3.4
     # via
     #   mkdocs
     #   mkdocs-get-deps
-mkdocs==1.6.1
+mkdocs==1.5.3
     # via
     #   -r requirements.in
     #   mkdocs-macros-plugin
@@ -63,7 +63,7 @@ mkdocs-get-deps==0.2.0
     # via mkdocs
 mkdocs-macros-plugin==1.2.0
     # via -r requirements.in
-mkdocs-material==9.5.34
+mkdocs-material==9.5.29
     # via -r requirements.in
 mkdocs-material-extensions==1.3
     # via mkdocs-material


### PR DESCRIPTION
Reverted MkDocs version from 1.6.1 to 1.5.3 and changed the mkdocs-material from 9.5.34 to 9.5.29 to correct the duplicate TOC entries.

Signed-off-by: Sreekala Gopakumar sreekala.gopakumar@ibm.com