### PR TITLE
Disable zlibNX onAIX by default

### DIFF
--- a/docs/version0.48.md
+++ b/docs/version0.48.md
@@ -1,0 +1,49 @@
+<!--
+* Copyright (c) 2017, 2024 IBM Corp. and others
+*
+* This program and the accompanying materials are made
+* available under the terms of the Eclipse Public License 2.0
+* which accompanies this distribution and is available at
+* https://www.eclipse.org/legal/epl-2.0/ or the Apache
+* License, Version 2.0 which accompanies this distribution and
+* is available at https://www.apache.org/licenses/LICENSE-2.0.
+*
+* This Source Code may also be made available under the
+* following Secondary Licenses when the conditions for such
+* availability set forth in the Eclipse Public License, v. 2.0
+* are satisfied: GNU General Public License, version 2 with
+* the GNU Classpath Exception [1] and GNU General Public
+* License, version 2 with the OpenJDK Assembly Exception [2].
+*
+* [1] https://www.gnu.org/software/classpath/license.html
+* [2] https://openjdk.org/legal/assembly-exception.html
+*
+* SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0 OR GPL-2.0-only WITH OpenJDK-assembly-exception-1.0
+-->
+
+# What's new in version 0.48.0
+
+The following new features and notable changes since version 0.47.0 are included in this release:
+
+- [New binaries and changes to supported environments](#binaries-and-supported-environments)
+- [Loading of the `zlibnx` library on AIX is disabled by default](#loading-of-the-zlibnx-library-on-aix-is-disabled-by-default)
+
+## Features and changes
+
+### Binaries and supported environments
+
+Eclipse OpenJ9&trade; release 0.48.0 supports OpenJDK 8, 11, 17, 21, and 23.
+
+To learn more about support for OpenJ9 releases, including OpenJDK levels and platform support, see [Supported environments](openj9_support.md).
+
+### Loading of the `zlibnx` library on AIX is disabled by default
+
+From release 0.25.0 onwards, `zlibNX` hardware-accelerated data compression and decompression was enabled by default on AIX&reg;. From this release onwards, loading of the `zlibnx` library on AIX is disabled by default because using `zlibNX` might cause a `ClassNotFoundException` error. You can enable adding of the `zlibNX` library by using the `-XX:+UseZlibNX` option.
+
+For more information, see [`-XX:[+|-]UseZlibNX`](xxusezlibnx.md).
+
+## Known problems and full release information
+
+To see known problems and a complete list of changes between Eclipse OpenJ9 v0.46.0 and v0.47.0 releases, see the [Release notes](https://github.com/eclipse-openj9/openj9/blob/master/doc/release-notes/0.47/0.47.md).
+
+<!-- ==== END OF TOPIC ==== version0.47.md ==== -->

--- a/docs/xxusezlibnx.md
+++ b/docs/xxusezlibnx.md
@@ -34,19 +34,21 @@ This option enables or disables the adding of the `zlibNX` library directory loc
 
 | Setting               | Effect  | Default                                                                            |
 |-----------------------|---------|:----------------------------------------------------------------------------------:|
-| `-XX:+UseZlibNX` |  Enable  |  :fontawesome-solid-check:{: .yes aria-hidden="true"}<span class="sr-only">yes</span>         |
-| `-XX:-UseZlibNX` | Disable |     |
+| `-XX:+UseZlibNX` |  Enable  |           |
+| `-XX:-UseZlibNX` | Disable |   :fontawesome-solid-check:{: .yes aria-hidden="true"}<span class="sr-only">yes</span>   |
 
 
 ## Explanation
 
 AIX system adds the `zlibNX` library location, if available, to the `LIBPATH` variable by default. But having the `zlibNX` library directory location in the `LIBPATH` variable might cause some issues. For example, Git clone fails when executed from Java&reg; when `zlibNX` is on the `LIBPATH` in the environment.
 
-You can disable adding of the `zlibNX` library location to the `LIBPATH` variable with the `-XX:-UseZlibNX` option.
+You can enable adding of the `zlibNX` library location to the `LIBPATH` variable with the `-XX:+UseZlibNX` option.
 
 ## See also
 
 - [Hardware acceleration](introduction.md#hardware-acceleration)
 - [Configuring your system](configuring.md)
+- [What's new in version 0.25.0](version0.25.md#enabling-zlibnx-hardware-accelerated-data-compression-and-decompression-on-aix)
+- [What's new in version 0.48.0](version0.48.md#loading-of-the-zlibnx-library-on-aix-is-disabled-by-default)
 
 <!-- ==== END OF TOPIC ==== xxusezlibnx.md ==== -->

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -101,6 +101,7 @@ nav:
 
     - "Release notes" :
         - "Overview"                                                             : openj9_releases.md
+        - "Version 0.48.0"                                                       : version0.48.md
         - "Version 0.47.0"                                                       : version0.47.md
         - "Version 0.46.1"                                                       : version0.46.1.md
         - "Version 0.46.0"                                                       : version0.46.md


### PR DESCRIPTION
https://github.com/eclipse-openj9/openj9-docs/issues/1426

Updated the related topics with the change in the default behavior related to the zlibNX library.

Closes #1426
Signed-off-by: Sreekala Gopakumar sreekala.gopakumar@ibm.com