### PR TITLE
Pull the Ubuntu 22.04 image from Amazon instead of Dockerhub

### DIFF
--- a/buildenv/Dockerfile
+++ b/buildenv/Dockerfile
@@ -20,7 +20,7 @@
 # SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0 OR GPL-2.0-only WITH OpenJDK-assembly-exception-1.0
 #
 
-FROM ubuntu:22.04@sha256:6042500cf4b44023ea1894effe7890666b0c5c7871ed83a97c36c76ae560bb9b
+FROM public.ecr.aws/lts/ubuntu:22.04_stable@sha256:1582c29f34a48752e406f1a261fe9545fad895da3f6bb4be55bc82485557564e
 MAINTAINER openj9.bot <openj9.bot@gmail.com>
 
 # Install basic requirementes from APT. Set up for SSH (including SSH login fix to prevent user being logged out), install and setup  virtualenv from pip3


### PR DESCRIPTION
Related to the Nov 15, 2024 change in Docker's subscription model, and ease of building the image at companies building the docs image for testing.

I tried building locally using the instructions at https://github.com/eclipse-openj9/openj9-docs/wiki/Testing-OpenJ9-MkDocs-dependencies and it worked.