### PR TITLE
Add documentation for -Xgc suballocator options

### DIFF
--- a/docs/allocation.md
+++ b/docs/allocation.md
@@ -161,6 +161,14 @@ installed (25 GB without APAR OA49416). All GC policies observe these limits exc
 
 When the VM uses compressed references, classes, threads, and monitors are stored in the lowest 4 GB of address space. However, this area of memory is also used by native libraries, the operating system, and for small Java heaps. If you receive native memory `OutOfMemoryError` exceptions in the lowest 4 GB when running with compressed references enabled, these errors might result from the lowest 4 GB of address space becoming full. Try specifying a large heap with the [`-Xmx`](xms.md) option, which puts the Java heap into a higher area of address space or using the [`-Xmcrs`](xmcrs.md) option to reserve space in the lowest 4 GB of address space for compressed references.
 
+You can control the compressed reference allocation with the following options:
+
+ - [`-Xgc:suballocatorCommitSize=<bytes>`](xgc.md#suballocatorcommitsize)
+ - [`-Xgc:suballocatorIncrementSize=<bytes>`](xgc.md#suballocatorincrementsize)
+ - [`-Xgc:suballocatorInitialSize=<bytes>`](xgc.md#suballocatorinitialsize)
+ - [`-Xgc:suballocatorQuickAllocDisable`](xgc.md#suballocatorquickallocdisable)
+ - [`-Xgc:suballocatorQuickAllocEnable`](xgc.md#suballocatorquickallocenable)
+
 To turn off compressed references, use the [`-Xnocompressedrefs`](xcompressedrefs.md) command-line option.
 
 

--- a/docs/version0.49.md
+++ b/docs/version0.49.md
@@ -27,6 +27,7 @@ The following new features and notable changes since version 0.48.0 are included
 
 - [New binaries and changes to supported environments](#binaries-and-supported-environments)
 - [Change to the shared classes cache generation number](#change-to-the-shared-classes-cache-generation-number)
+- [`-Xgc` options for suballocator heap size added to control the compressed reference allocation](#xgc-options-for-suballocator-heap-size-added-to-control-the-compressed-reference-allocation)
 
 ## Features and changes
 
@@ -45,6 +46,18 @@ The shared classes cache generation number is incremented. The increment in the 
 To save space, all existing shared caches can be removed unless they are in use by an earlier release. For more information, see [Housekeeping](shrc.md#housekeeping) and [`-Xshareclasses`](xshareclasses.md).
 
 The shared classes cache generation number is modified because of a change in the format of ROMClasses that are stored in the shared classes cache. A new flag `J9AccClassIsShared` is added to ROMClasses to indicate whether a ROMClass was loaded from a shared classes cache or from a VM.
+
+### `-Xgc` options for suballocator heap size added to control the compressed reference allocation
+
+The VM can use compressed references to decrease the size of Java objects and make better use of the available space in the Java heap. You can now control the compressed reference allocation with the following options:
+
+ - [`-Xgc:suballocatorCommitSize=<bytes>`](xgc.md#suballocatorcommitsize)
+ - [`-Xgc:suballocatorIncrementSize=<bytes>`](xgc.md#suballocatorincrementsize)
+ - [`-Xgc:suballocatorInitialSize=<bytes>`](xgc.md#suballocatorinitialsize)
+ - [`-Xgc:suballocatorQuickAllocDisable`](xgc.md#suballocatorquickallocdisable)
+ - [`-Xgc:suballocatorQuickAllocEnable`](xgc.md#suballocatorquickallocenable)
+
+For more information, see [Compressed references](allocation.md#compressed-references).
 
 ## Known problems and full release information
 

--- a/docs/xgc.md
+++ b/docs/xgc.md
@@ -51,6 +51,11 @@ Options that change the behavior of the garbage collector.
 | [`scvNoAdaptiveTenure`              ](#scvnoadaptivetenure              ) | Turns off the adaptive tenure age in the generational concurrent GC policy.                               |
 | [`scvTenureAge`                     ](#scvtenureage                     ) | Sets the initial scavenger tenure age in the generational concurrent GC policy.                           |
 | [`stdGlobalCompactToSatisfyAllocate`](#stdglobalcompacttosatisfyallocate) | Prevents the GC from performing a compaction unless absolutely required.                                  |
+| [`suballocatorCommitSize`           ](#suballocatorcommitsize           ) | Sets the commit size in bytes for the heap that is used for compressed references.                                |
+| [`suballocatorIncrementSize`        ](#suballocatorincrementsize        ) | Sets the reservation increment size in bytes for the heap that is used for compressed references.                 |
+| [`suballocatorInitialSize`          ](#suballocatorinitialsize          ) | Sets the initial size in bytes for the heap that is used for compressed references.                               |
+| [`suballocatorQuickAllocDisable`    ](#suballocatorquickallocdisable    ) | Disable mmap-based allocation for compressed references (Linux only).                             |
+| [`suballocatorQuickAllocEnable`     ](#suballocatorquickallocenable     ) | Enables mmap-based allocation for compressed references (Linux only).                             |
 | [`synchronousGCOnOOM`               ](#synchronousgconoom               )     | Stops an application to allow GC activity.                                                                             |
 | [`targetPausetime`                  ](#targetpausetime                  )   | Sets the target GC pause time for the `metronome` and `balanced` GC policies.                            |
 | [`targetUtilization`                ](#targetutilization                )   | Sets application utilization for the `metronome` GC policy.                                                   |
@@ -272,6 +277,47 @@ the dynamic compaction triggers that look at heap occupancy. This option works o
 
 : This option is not supported with the balanced GC policy (`-Xgcpolicy:balanced`) or metronome GC policy (`-Xgcpolicy:metronome`).
 
+### `suballocatorCommitSize`
+
+        -Xgc:suballocatorCommitSize=<bytes>
+
+: Sets the commit size of the heap that is used for compressed references. The default size is 50 MB.
+
+: You can use this option with all OpenJ9 GC policies. The option affects only those builds that use compressed references.
+
+### `suballocatorIncrementSize`
+
+        -Xgc:suballocatorIncrementSize=<bytes>
+
+: Sets the reservation increment size of the heap that is used for compressed references. When the memory of the current heap space is exhausted, the increment size determines the amount of additional memory to reserve. The default size is 8 MB for all platforms except AIX. The default size for AIX is 256 MB.
+
+: You can use this option with all OpenJ9 GC policies. The option affects only those builds that use compressed references.
+
+### `suballocatorInitialSize`
+
+        -Xgc:suballocatorInitialSize=<bytes>
+
+: Sets the initial size of the heap that is used for compressed references. The default size is 200 MB.
+
+: You can use this option with all OpenJ9 GC policies. The option affects only those builds that use compressed references.
+
+### `suballocatorQuickAllocDisable`
+**Linux only**
+
+        -Xgc:suballocatorQuickAllocDisable
+
+: Disables mmap-based allocation for compressed references.
+
+: You can use this option with all OpenJ9 GC policies. The option affects only those builds that use compressed references.
+ 
+### `suballocatorQuickAllocEnable`
+**Linux only**
+
+        -Xgc:suballocatorQuickAllocEnable
+
+: Enables mmap-based allocation for compressed references. This option is enabled by default.
+
+: You can use this option with all OpenJ9 GC policies. The option affects only those builds that use compressed references.
 
 ### `synchronousGCOnOOM`
 
@@ -356,5 +402,8 @@ Larger TLHs can help reduce heap lock contention, but might also reduce heap uti
     :fontawesome-solid-pencil:{: .note aria-hidden="true"} **Note:** The cycle time does not mean that the summary information is logged precisely at that time, but when the last GC event that meets this time criterion passes.
 
 : This option applies only to the `metronome` GC policy.
+
+
+ 
 
 <!-- ==== END OF TOPIC ==== xgc.md ==== -->


### PR DESCRIPTION
https://github.com/eclipse-openj9/openj9-docs/issues/1418

Added new `-Xgc` options in the related topics.

Closes #1418
Signed-off-by: Sreekala Gopakumar sreekala.gopakumar@ibm.com