### PR TITLE
AIX compiler updated to 16.1.0.20, Runtime required is 16.1.0.10

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -187,10 +187,10 @@ The user documentation supports the configuration, tuning, and diagnosis of the 
 - ![Java 20 and later](docs/cr/java20plus.png) -  For content that applies to an OpenJDK version 20 or later version.
 - ![Java 21](docs/cr/java21.png) - For content that applies only to an OpenJDK version 21.
 - ![Java 21 and later](docs/cr/java21plus.png) -  For content that applies to an OpenJDK version 21 or later version.
-- ![Java 22](docs/cr/java22.png) - For content that applies only to an OpenJDK version 24.
-- ![Java 22 and later](docs/cr/java22plus.png) -  For content that applies to an OpenJDK version 24 or later version.
-- ![Java 23](docs/cr/java23.png) - For content that applies only to an OpenJDK version 24.
-- ![Java 23 and later](docs/cr/java23plus.png) -  For content that applies to an OpenJDK version 24 or later version.
+- ![Java 22](docs/cr/java22.png) - For content that applies only to an OpenJDK version 22.
+- ![Java 22 and later](docs/cr/java22plus.png) -  For content that applies to an OpenJDK version 22 or later version.
+- ![Java 23](docs/cr/java23.png) - For content that applies only to an OpenJDK version 23.
+- ![Java 23 and later](docs/cr/java23plus.png) -  For content that applies to an OpenJDK version 23 or later version.
 - ![Java 24](docs/cr/java24.png) - For content that applies only to an OpenJDK version 24.
 - ![Java 24 and later](docs/cr/java24plus.png) -  For content that applies to an OpenJDK version 24 or later version.
 

--- a/docs/openj9_support.md
+++ b/docs/openj9_support.md
@@ -42,15 +42,13 @@ columns will be removed over time.
 
 ## Eclipse OpenJ9 releases
 
-| OpenJ9 release | Release date  | JDK8 (LTS) | JDK11 (LTS) | JDK17 (LTS) | JDK21 (LTS) | JDK22 | JDK23 |  JDK24  |
-|----------------|---------------|------------|-------------|-------------|-------------|-------|-------|---------|
-| 0.46.0         | Aug 2024   |  :fontawesome-solid-check:{: .yes aria-hidden="true"}<span class="sr-only">yes</span>   | :fontawesome-solid-check:{: .yes aria-hidden="true"}<span class="sr-only">yes</span>   |  :fontawesome-solid-check:{: .yes aria-hidden="true"}<span class="sr-only">yes</span>     |    :fontawesome-solid-check:{: .yes aria-hidden="true"}<span class="sr-only">yes</span>       |    :fontawesome-solid-check:{: .yes aria-hidden="true"}<span class="sr-only">yes</span>          |             |      |
-| 0.46.1         | Sep 2024   |  :fontawesome-solid-check:{: .yes aria-hidden="true"}<span class="sr-only">yes</span>   | :fontawesome-solid-check:{: .yes aria-hidden="true"}<span class="sr-only">yes</span>   |  :fontawesome-solid-check:{: .yes aria-hidden="true"}<span class="sr-only">yes</span>     |    :fontawesome-solid-check:{: .yes aria-hidden="true"}<span class="sr-only">yes</span>       |    :fontawesome-solid-check:{: .yes aria-hidden="true"}<span class="sr-only">yes</span>          |             |      |
-| 0.47.0         | Sep 2024 (2)   |  :fontawesome-solid-xmark:{: .no aria-hidden="true"}<span class="sr-only">no</span>   | :fontawesome-solid-xmark:{: .no aria-hidden="true"}<span class="sr-only">no</span>   | :fontawesome-solid-xmark:{: .no aria-hidden="true"}<span class="sr-only">no</span>     |    :fontawesome-solid-xmark:{: .no aria-hidden="true"}<span class="sr-only">no</span>       |    :fontawesome-solid-xmark:{: .no aria-hidden="true"}<span class="sr-only">no</span>          |     :fontawesome-solid-check:{: .yes aria-hidden="true"}<span class="sr-only">yes</span>              |       |
-| 0.48.0         | Nov 2024   |  :fontawesome-solid-check:{: .yes aria-hidden="true"}<span class="sr-only">yes</span>   | :fontawesome-solid-check:{: .yes aria-hidden="true"}<span class="sr-only">yes</span>   |  :fontawesome-solid-check:{: .yes aria-hidden="true"}<span class="sr-only">yes</span>     |    :fontawesome-solid-check:{: .yes aria-hidden="true"}<span class="sr-only">yes</span>       |     :fontawesome-solid-xmark:{: .no aria-hidden="true"}<span class="sr-only">no</span>              |    :fontawesome-solid-check:{: .yes aria-hidden="true"}<span class="sr-only">yes</span>             |        |
-| 0.49.0         | Feb 2025   |  :fontawesome-solid-check:{: .yes aria-hidden="true"}<span class="sr-only">yes</span>   | :fontawesome-solid-check:{: .yes aria-hidden="true"}<span class="sr-only">yes</span>   |  :fontawesome-solid-check:{: .yes aria-hidden="true"}<span class="sr-only">yes</span>     |    :fontawesome-solid-check:{: .yes aria-hidden="true"}<span class="sr-only">yes</span>       |     :fontawesome-solid-xmark:{: .no aria-hidden="true"}<span class="sr-only">no</span>              |    :fontawesome-solid-check:{: .yes aria-hidden="true"}<span class="sr-only">yes</span>             |         |
-| 0.50.0         | Mar 2025 (2)   |  :fontawesome-solid-xmark:{: .no aria-hidden="true"}<span class="sr-only">no</span>  | :fontawesome-solid-xmark:{: .no aria-hidden="true"}<span class="sr-only">no</span>   |  :fontawesome-solid-xmark:{: .no aria-hidden="true"}<span class="sr-only">no</span>     |    :fontawesome-solid-xmark:{: .no aria-hidden="true"}<span class="sr-only">no</span>       |     :fontawesome-solid-xmark:{: .no aria-hidden="true"}<span class="sr-only">no</span>              |    :fontawesome-solid-xmark:{: .no aria-hidden="true"}<span class="sr-only">no</span>             |   :fontawesome-solid-check:{: .yes aria-hidden="true"}<span class="sr-only">yes</span>        |
-| 0.51.0         | May 2025 (1)   |   :fontawesome-solid-check:{: .yes aria-hidden="true"}<span class="sr-only">yes</span>   | :fontawesome-solid-check:{: .yes aria-hidden="true"}<span class="sr-only">yes</span>   |  :fontawesome-solid-check:{: .yes aria-hidden="true"}<span class="sr-only">yes</span>     |    :fontawesome-solid-check:{: .yes aria-hidden="true"}<span class="sr-only">yes</span>       |     :fontawesome-solid-xmark:{: .no aria-hidden="true"}<span class="sr-only">no</span>              |    :fontawesome-solid-xmark:{: .no aria-hidden="true"}<span class="sr-only">no</span>             |   :fontawesome-solid-check:{: .yes aria-hidden="true"}<span class="sr-only">yes</span>       |
+| OpenJ9 release | Release date  | JDK8 (LTS) | JDK11 (LTS) | JDK17 (LTS) | JDK21 (LTS) | JDK23 |
+|----------------|---------------|------------|-------------|-------------|-------------|-------|
+| 0.47.0         | Sep 2024 (2)   |  :fontawesome-solid-xmark:{: .no aria-hidden="true"}<span class="sr-only">no</span>   | :fontawesome-solid-xmark:{: .no aria-hidden="true"}<span class="sr-only">no</span>   | :fontawesome-solid-xmark:{: .no aria-hidden="true"}<span class="sr-only">no</span>     |    :fontawesome-solid-xmark:{: .no aria-hidden="true"}<span class="sr-only">no</span>       |     :fontawesome-solid-check:{: .yes aria-hidden="true"}<span class="sr-only">yes</span>              |
+| 0.48.0         | Nov 2024   |  :fontawesome-solid-check:{: .yes aria-hidden="true"}<span class="sr-only">yes</span>   | :fontawesome-solid-check:{: .yes aria-hidden="true"}<span class="sr-only">yes</span>   |  :fontawesome-solid-check:{: .yes aria-hidden="true"}<span class="sr-only">yes</span>     |    :fontawesome-solid-check:{: .yes aria-hidden="true"}<span class="sr-only">yes</span>       |   :fontawesome-solid-check:{: .yes aria-hidden="true"}<span class="sr-only">yes</span>             |
+| 0.49.0         | Feb 2025   |  :fontawesome-solid-check:{: .yes aria-hidden="true"}<span class="sr-only">yes</span>   | :fontawesome-solid-check:{: .yes aria-hidden="true"}<span class="sr-only">yes</span>   |  :fontawesome-solid-check:{: .yes aria-hidden="true"}<span class="sr-only">yes</span>     |    :fontawesome-solid-check:{: .yes aria-hidden="true"}<span class="sr-only">yes</span>       |   :fontawesome-solid-check:{: .yes aria-hidden="true"}<span class="sr-only">yes</span>             |
+| 0.51.0         | May 2025   |   :fontawesome-solid-check:{: .yes aria-hidden="true"}<span class="sr-only">yes</span>   | :fontawesome-solid-check:{: .yes aria-hidden="true"}<span class="sr-only">yes</span>   |  :fontawesome-solid-check:{: .yes aria-hidden="true"}<span class="sr-only">yes</span>     |     :fontawesome-solid-check:{: .yes aria-hidden="true"}<span class="sr-only">yes</span>                 |    :fontawesome-solid-xmark:{: .no aria-hidden="true"}<span class="sr-only">no</span>             |
+| 0.53.0         | Jul 2025 (1)   |   :fontawesome-solid-check:{: .yes aria-hidden="true"}<span class="sr-only">yes</span>   | :fontawesome-solid-check:{: .yes aria-hidden="true"}<span class="sr-only">yes</span>   |  :fontawesome-solid-check:{: .yes aria-hidden="true"}<span class="sr-only">yes</span>     |    :fontawesome-solid-check:{: .yes aria-hidden="true"}<span class="sr-only">yes</span>       |   :fontawesome-solid-xmark:{: .no aria-hidden="true"}<span class="sr-only">no</span>             |
 
 :fontawesome-solid-pencil:{: .note aria-hidden="true"} **Notes:**
 
@@ -74,7 +72,6 @@ OpenJDK 8 binaries are expected to function on the minimum operating system leve
 |-------------------------------------------|--------------------------------------------------------------------------------------|--------------------------------------------------------------------------------------|--------------------------------------------------------------------------------------|--------------------------------------------------------------------------------------|--------------------------------------------------------------------------------------|--------------------------------------------------------------------------------------|
 | RHEL 8.8                                  | :fontawesome-solid-check:{: .yes aria-hidden="true"}<span class="sr-only">yes</span> | :fontawesome-solid-xmark:{: .no aria-hidden="true"}<span class="sr-only">no</span>   | :fontawesome-solid-check:{: .yes aria-hidden="true"}<span class="sr-only">yes</span> | :fontawesome-solid-check:{: .yes aria-hidden="true"}<span class="sr-only">yes</span> | :fontawesome-solid-xmark:{: .no aria-hidden="true"}<span class="sr-only">no</span>   | :fontawesome-solid-check:{: .yes aria-hidden="true"}<span class="sr-only">yes</span> |
 | RHEL 9.2                                  | :fontawesome-solid-xmark:{: .no aria-hidden="true"}<span class="sr-only">no</span> | :fontawesome-solid-xmark:{: .no aria-hidden="true"}<span class="sr-only">no</span>   | :fontawesome-solid-check:{: .yes aria-hidden="true"}<span class="sr-only">yes</span> | :fontawesome-solid-check:{: .yes aria-hidden="true"}<span class="sr-only">yes</span> | :fontawesome-solid-xmark:{: .no aria-hidden="true"}<span class="sr-only">no</span>   | :fontawesome-solid-check:{: .yes aria-hidden="true"}<span class="sr-only">yes</span> |
-| Ubuntu 20.04                              | :fontawesome-solid-check:{: .yes aria-hidden="true"}<span class="sr-only">yes</span> | :fontawesome-solid-xmark:{: .no aria-hidden="true"}<span class="sr-only">no</span> | :fontawesome-solid-check:{: .yes aria-hidden="true"}<span class="sr-only">yes</span> | :fontawesome-solid-check:{: .yes aria-hidden="true"}<span class="sr-only">yes</span> | :fontawesome-solid-xmark:{: .no aria-hidden="true"}<span class="sr-only">no </span>  | :fontawesome-solid-check:{: .yes aria-hidden="true"}<span class="sr-only">yes</span> |
 | Ubuntu 22.04                              | :fontawesome-solid-xmark:{: .no aria-hidden="true"}<span class="sr-only">no</span> | :fontawesome-solid-xmark:{: .no aria-hidden="true"}<span class="sr-only">no</span> | :fontawesome-solid-check:{: .yes aria-hidden="true"}<span class="sr-only">yes</span> | :fontawesome-solid-check:{: .yes aria-hidden="true"}<span class="sr-only">yes</span> | :fontawesome-solid-xmark:{: .no aria-hidden="true"}<span class="sr-only">no </span>  | :fontawesome-solid-check:{: .yes aria-hidden="true"}<span class="sr-only">yes</span> |
 
 :fontawesome-solid-pencil:{: .note aria-hidden="true"} **Notes:**
@@ -104,7 +101,7 @@ OpenJDK 8 binaries are expected to function on the minimum operating system leve
 |-------------------------------------------|--------------------------------------------------------------------------------------|--------------------------------------------------------------------------------------|
 | AIX 7.2 TL5                               | :fontawesome-solid-check:{: .yes aria-hidden="true"}<span class="sr-only">yes</span> | :fontawesome-solid-check:{: .yes aria-hidden="true"}<span class="sr-only">yes</span> |
 
-:fontawesome-solid-bell:{: .warn aria-hidden="true"} **Important:** AIX OpenJ9 builds require the [XL C++ Runtime 16.1.0.7 or later](https://www.ibm.com/support/pages/fix-list-xl-cc-runtime-aix#161X).
+:fontawesome-solid-bell:{: .warn aria-hidden="true"} **Important:** From the 0.51.0 release onwards, AIX OpenJ9 builds require the [XL C++ Runtime 16.1.0.10 or later](https://www.ibm.com/support/pages/fix-list-xl-cc-runtime-aix#161X).
 
 When public support for an operating system version ends, OpenJ9 can no longer be supported on that level.
 
@@ -117,7 +114,6 @@ OpenJDK 11 binaries are expected to function on the minimum operating system lev
 |-------------------------------------------|--------------------------------------------------------------------------------------|--------------------------------------------------------------------------------------|--------------------------------------------------------------------------------------|--------------------------------------------------------------------------------------|
 | RHEL 8.8                                  | :fontawesome-solid-check:{: .yes aria-hidden="true"}<span class="sr-only">yes</span> | :fontawesome-solid-check:{: .yes aria-hidden="true"}<span class="sr-only">yes</span> | :fontawesome-solid-check:{: .yes aria-hidden="true"}<span class="sr-only">yes</span> | :fontawesome-solid-check:{: .yes aria-hidden="true"}<span class="sr-only">yes</span> |
 | RHEL 9.2                                  | :fontawesome-solid-xmark:{: .no aria-hidden="true"}<span class="sr-only">no</span> | :fontawesome-solid-check:{: .yes aria-hidden="true"}<span class="sr-only">yes</span> | :fontawesome-solid-check:{: .yes aria-hidden="true"}<span class="sr-only">yes</span> | :fontawesome-solid-check:{: .yes aria-hidden="true"}<span class="sr-only">yes</span> |
-| Ubuntu 20.04                              | :fontawesome-solid-check:{: .yes aria-hidden="true"}<span class="sr-only">yes</span> | :fontawesome-solid-check:{: .yes aria-hidden="true"}<span class="sr-only">yes</span> | :fontawesome-solid-check:{: .yes aria-hidden="true"}<span class="sr-only">yes</span> | :fontawesome-solid-check:{: .yes aria-hidden="true"}<span class="sr-only">yes</span> |
 | Ubuntu 22.04                              | :fontawesome-solid-xmark:{: .no aria-hidden="true"}<span class="sr-only">no</span> | :fontawesome-solid-check:{: .yes aria-hidden="true"}<span class="sr-only">yes</span> | :fontawesome-solid-check:{: .yes aria-hidden="true"}<span class="sr-only">yes</span> | :fontawesome-solid-check:{: .yes aria-hidden="true"}<span class="sr-only">yes</span> |
 
 :fontawesome-solid-pencil:{: .note aria-hidden="true"} **Notes:**
@@ -147,7 +143,7 @@ OpenJDK 11 binaries are expected to function on the minimum operating system lev
 |-------------------------------------------|--------------------------------------------------------------------------------------|
 | AIX 7.2 TL5                               | :fontawesome-solid-check:{: .yes aria-hidden="true"}<span class="sr-only">yes</span> |
 
-:fontawesome-solid-bell:{: .warn aria-hidden="true"} **Important:** AIX OpenJ9 builds require the [XL C++ Runtime 16.1.0.7 or later](https://www.ibm.com/support/pages/fix-list-xl-cc-runtime-aix#161X).
+:fontawesome-solid-bell:{: .warn aria-hidden="true"} **Important:** From the 0.51.0 release onwards, AIX OpenJ9 builds require the [XL C++ Runtime 16.1.0.10 or later](https://www.ibm.com/support/pages/fix-list-xl-cc-runtime-aix#161X).
 
 When public support for an operating system version ends, OpenJ9 can no longer be supported on that level.
 
@@ -160,7 +156,6 @@ OpenJDK 17 binaries are expected to function on the minimum operating system lev
 |-------------------------------------------|--------------------------------------------------------------------------------------|--------------------------------------------------------------------------------------|--------------------------------------------------------------------------------------|--------------------------------------------------------------------------------------|
 | RHEL 8.8                                  | :fontawesome-solid-check:{: .yes aria-hidden="true"}<span class="sr-only">yes</span> | :fontawesome-solid-check:{: .yes aria-hidden="true"}<span class="sr-only">yes</span> | :fontawesome-solid-check:{: .yes aria-hidden="true"}<span class="sr-only">yes</span> | :fontawesome-solid-check:{: .yes aria-hidden="true"}<span class="sr-only">yes</span> |
 | RHEL 9.2                                  | :fontawesome-solid-xmark:{: .no aria-hidden="true"}<span class="sr-only">no</span> | :fontawesome-solid-check:{: .yes aria-hidden="true"}<span class="sr-only">yes</span> | :fontawesome-solid-check:{: .yes aria-hidden="true"}<span class="sr-only">yes</span> | :fontawesome-solid-check:{: .yes aria-hidden="true"}<span class="sr-only">yes</span> |
-| Ubuntu 20.04                              | :fontawesome-solid-check:{: .yes aria-hidden="true"}<span class="sr-only">yes</span> | :fontawesome-solid-check:{: .yes aria-hidden="true"}<span class="sr-only">yes</span> | :fontawesome-solid-check:{: .yes aria-hidden="true"}<span class="sr-only">yes</span> | :fontawesome-solid-check:{: .yes aria-hidden="true"}<span class="sr-only">yes</span> |
 | Ubuntu 22.04                              | :fontawesome-solid-xmark:{: .no aria-hidden="true"}<span class="sr-only">no</span> | :fontawesome-solid-check:{: .yes aria-hidden="true"}<span class="sr-only">yes</span> | :fontawesome-solid-check:{: .yes aria-hidden="true"}<span class="sr-only">yes</span> | :fontawesome-solid-check:{: .yes aria-hidden="true"}<span class="sr-only">yes</span> |
 
 :fontawesome-solid-pencil:{: .note aria-hidden="true"} **Note:** Not all of these distributions are tested, but the following distributions are expected to function without problems:
@@ -186,7 +181,7 @@ OpenJDK 17 binaries are expected to function on the minimum operating system lev
 |-------------------------------------------|--------------------------------------------------------------------------------------|
 | AIX 7.2 TL5                               | :fontawesome-solid-check:{: .yes aria-hidden="true"}<span class="sr-only">yes</span> |
 
-:fontawesome-solid-bell:{: .warn aria-hidden="true"} **Important:** AIX OpenJ9 builds require the [XL C++ Runtime 16.1.0.7 or later](https://www.ibm.com/support/pages/fix-list-xl-cc-runtime-aix#161X).
+:fontawesome-solid-bell:{: .warn aria-hidden="true"} **Important:** From the 0.51.0 release onwards, AIX OpenJ9 builds require the [XL C++ Runtime 16.1.0.10 or later](https://www.ibm.com/support/pages/fix-list-xl-cc-runtime-aix#161X).
 
 When public support for an operating system version ends, OpenJ9 can no longer be supported on that level.
 
@@ -199,7 +194,6 @@ OpenJDK 21 and later binaries are expected to function on the minimum operating 
 |-------------------------------------------|--------------------------------------------------------------------------------------|--------------------------------------------------------------------------------------|--------------------------------------------------------------------------------------|--------------------------------------------------------------------------------------|
 | RHEL 8.8                                  | :fontawesome-solid-check:{: .yes aria-hidden="true"}<span class="sr-only">yes</span> | :fontawesome-solid-check:{: .yes aria-hidden="true"}<span class="sr-only">yes</span> | :fontawesome-solid-check:{: .yes aria-hidden="true"}<span class="sr-only">yes</span> | :fontawesome-solid-check:{: .yes aria-hidden="true"}<span class="sr-only">yes</span> |
 | RHEL 9.2                                  | :fontawesome-solid-xmark:{: .no aria-hidden="true"}<span class="sr-only">no</span> | :fontawesome-solid-check:{: .yes aria-hidden="true"}<span class="sr-only">yes</span> | :fontawesome-solid-check:{: .yes aria-hidden="true"}<span class="sr-only">yes</span> | :fontawesome-solid-check:{: .yes aria-hidden="true"}<span class="sr-only">yes</span> |
-| Ubuntu 20.04                              | :fontawesome-solid-check:{: .yes aria-hidden="true"}<span class="sr-only">yes</span> | :fontawesome-solid-check:{: .yes aria-hidden="true"}<span class="sr-only">yes</span> | :fontawesome-solid-check:{: .yes aria-hidden="true"}<span class="sr-only">yes</span> | :fontawesome-solid-check:{: .yes aria-hidden="true"}<span class="sr-only">yes</span> |
 | Ubuntu 22.04                              | :fontawesome-solid-xmark:{: .no aria-hidden="true"}<span class="sr-only">no</span> | :fontawesome-solid-check:{: .yes aria-hidden="true"}<span class="sr-only">yes</span> | :fontawesome-solid-check:{: .yes aria-hidden="true"}<span class="sr-only">yes</span> | :fontawesome-solid-check:{: .yes aria-hidden="true"}<span class="sr-only">yes</span> |
 
 :fontawesome-solid-pencil:{: .note aria-hidden="true"} **Note:** Not all of these distributions are tested, but the following distributions are expected to function without problems:
@@ -226,7 +220,7 @@ OpenJDK 21 and later binaries are expected to function on the minimum operating 
 |-------------------------------------------|--------------------------------------------------------------------------------------|
 | AIX 7.2 TL5                               | :fontawesome-solid-check:{: .yes aria-hidden="true"}<span class="sr-only">yes</span> |
 
-:fontawesome-solid-bell:{: .warn aria-hidden="true"} **Important:** AIX OpenJ9 builds require the [XL C++ Runtime 16.1.0.7 or later](https://www.ibm.com/support/pages/fix-list-xl-cc-runtime-aix#161X).
+:fontawesome-solid-bell:{: .warn aria-hidden="true"} **Important:** From the 0.51.0 release onwards, AIX OpenJ9 builds require the [XL C++ Runtime 16.1.0.10 or later](https://www.ibm.com/support/pages/fix-list-xl-cc-runtime-aix#161X).
 
 When public support for an operating system version ends, OpenJ9 can no longer be supported on that level.
 
@@ -245,7 +239,7 @@ The project builds and tests OpenJDK with OpenJ9 on a number of platforms. The o
 | Windows x86 32-bit            | Windows Server 2019    | Microsoft Visual Studio 2022          |
 | Windows x86 64-bit            | Windows Server 2019    | Microsoft Visual Studio 2022          |
 | macOS x86 64-bit              | OSX 10.15.7            | xcode 12.4 and clang 12.0.0           |
-| AIX POWER BE 64-bit           | AIX 7.2 TL5            | xlc/C++ 16.1.0.11                        |
+| AIX POWER BE 64-bit           | AIX 7.2 TL5            | xlc/C++ 16.1.0.20                        |
 
 ### OpenJDK 11
 
@@ -258,7 +252,7 @@ The project builds and tests OpenJDK with OpenJ9 on a number of platforms. The o
 | Windows x86 64-bit            | Windows Server 2019    | Microsoft Visual Studio 2022          |
 | macOS x86 64-bit              | macOS 10.15.7          | xcode 12.4 and clang 12.0.0           |
 | macOS AArch64                 | macOS 11.5.2           | xcode 13.0 and clang 13.0.0           |
-| AIX POWER BE 64-bit           | AIX 7.2 TL5            | xlc/C++ 16.1.0.11                     |
+| AIX POWER BE 64-bit           | AIX 7.2 TL5            | xlc/C++ 16.1.0.20                     |
 
 ### OpenJDK 17
 
@@ -271,7 +265,7 @@ The project builds and tests OpenJDK with OpenJ9 on a number of platforms. The o
 | Windows x86 64-bit            | Windows Server 2019    | Microsoft Visual Studio 2022          |
 | macOS x86 64-bit              | macOS 10.15.7          | xcode 12.4 and clang 12.0.0           |
 | macOS AArch64                 | macOS 11.5.2           | xcode 13.0 and clang 13.0.0           |
-| AIX POWER BE 64-bit           | AIX 7.2 TL5            | xlc/C++ 16.1.0.11                     |
+| AIX POWER BE 64-bit           | AIX 7.2 TL5            | xlc/C++ 16.1.0.20                     |
 
 ### OpenJDK 21 and later
 
@@ -284,4 +278,4 @@ The project builds and tests OpenJDK with OpenJ9 on a number of platforms. The o
 | Windows x86 64-bit            | Windows Server 2019    | Microsoft Visual Studio 2022          |
 | macOS x86 64-bit              | macOS 10.15.7          | xcode 12.4 and clang 12.0.0           |
 | macOS AArch64                 | macOS 11.5.2           | xcode 13.0 and clang 13.0.0           |
-| AIX POWER BE 64-bit           | AIX 7.2 TL5            | xlc/C++ 16.1.0.11                     |
+| AIX POWER BE 64-bit           | AIX 7.2 TL5            | xlc/C++ 16.1.0.20                    |

--- a/docs/version0.51.md
+++ b/docs/version0.51.md
@@ -21,21 +21,22 @@
 * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0 OR GPL-2.0-only WITH OpenJDK-assembly-exception-1.0
 -->
 
-# What's new in version 0.50.0
+# What's new in version 0.51.0
 
 The following new features and notable changes since version 0.49.0 are included in this release:
 
 - [New binaries and changes to supported environments](#binaries-and-supported-environments)
 - [New parameter `maxstringlength` added to the `-Xtrace` option](#new-parameter-maxstringlength-added-to-the-xtrace-option)
-- ![Start of content that applies to Java 24 and later](cr/java24plus.png) [New JDK 24 features](#new-jdk-24-features) ![End of content that applies to Java 24 and later](cr/java_close.png)
+- [XL C++ Runtime 16.1.0.10 or later required for AIX OpenJ9 builds](#xl-c-runtime-161010-or-later-required-for-aix-openj9-builds)
+<!--Release 0.50.0 cancelled- ![Start of content that applies to Java 24 and later](cr/java24plus.png) [New JDK 24 features](#new-jdk-24-features) ![End of content that applies to Java 24 and later](cr/java_close.png)-->
 
 ## Features and changes
 
 ### Binaries and supported environments
 
-Eclipse OpenJ9&trade; release 0.50.0 supports OpenJDK 24.
+Eclipse OpenJ9&trade; release 0.51.0 supports OpenJDK 8, 11, 17, and 21.
 
-OpenJDK 24 with Eclipse OpenJ9 is *not* a long term support (LTS) release.
+Ubuntu 20.04 is removed from the list of supported platforms.
 
 To learn more about support for OpenJ9 releases, including OpenJDK levels and platform support, see [Supported environments](openj9_support.md).
 
@@ -45,7 +46,11 @@ You can use the `maxstringlength` parameter of the `-Xtrace` option to specify t
 
 For more information, see [`maxstringlength`](xtrace.md#maxstringlength).
 
-### ![Start of content that applies to Java 24 and later](cr/java24plus.png) New JDK 24 features
+### XL C++ Runtime 16.1.0.10 or later required for AIX OpenJ9 builds
+
+AIX OpenJ9 builds now require version 16.1.0.10 or later of the [IBM XL C++ Runtime](https://www.ibm.com/support/pages/fix-list-xl-cc-runtime-aix#161X).
+
+<!--### ![Start of content that applies to Java 24 and later](cr/java24plus.png) New JDK 24 features
 
 The following features are supported by OpenJ9:
 
@@ -72,9 +77,9 @@ The following features are implemented in OpenJDK and available in any build of 
 
 You can find the full list of features for JDK 24 at the [OpenJDK project](https://openjdk.org/projects/jdk/24/).
 Any remaining features that are listed either do not apply to OpenJ9 or are not implemented and hence not applicable to OpenJ9 in this release. ![End of content that applies to Java 24 and later](cr/java_close.png)
-
+-->
 ## Known problems and full release information
 
-To see known problems and a complete list of changes between Eclipse OpenJ9 v0.49.0 and v0.50.0 releases, see the [Release notes](https://github.com/eclipse-openj9/openj9/blob/master/doc/release-notes/0.50/0.50.md).
+To see known problems and a complete list of changes between Eclipse OpenJ9 v0.49.0 and v0.51.0 releases, see the [Release notes](https://github.com/eclipse-openj9/openj9/blob/master/doc/release-notes/0.51/0.51.md).
 
-<!-- ==== END OF TOPIC ==== version0.50.md ==== -->
+<!-- ==== END OF TOPIC ==== version0.51.md ==== -->

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -101,7 +101,7 @@ nav:
 
     - "Release notes" :
         - "Overview"                                                             : openj9_releases.md
-        - "Version 0.50.0"                                                       : version0.50.md
+        - "Version 0.51.0"                                                       : version0.51.md
         - "Version 0.49.0"                                                       : version0.49.md
         - "Version 0.48.0"                                                       : version0.48.md
         - "Version 0.47.0"                                                       : version0.47.md


### PR DESCRIPTION
https://github.com/eclipse-openj9/openj9-docs/issues/1498

Updated the Supported environments topic.

Closes #1498
Signed-off-by: Sreekala Gopakumar sreekala.gopakumar@ibm.com