### PR TITLE
Document new DAA api added in 0.46.0

### DIFF
--- a/docs/api-overview.md
+++ b/docs/api-overview.md
@@ -32,6 +32,7 @@ If your Java application manipulates native data, the Data Access Accelerator AP
 - performing arithmetic, comparison, and validation of packed decimal data
 - converting between decimal data types as well as to and from `BigDecimal` and `BigInteger` types
 - marshalling Java binary types to and from byte arrays
+- validating the sign and digits of a given external decimal input before operating on the data.
 
 ## GPU acceleration
 

--- a/docs/introduction.md
+++ b/docs/introduction.md
@@ -57,12 +57,14 @@ The following functions are provided:
 - Arithmetic, comparison, shifting, and validation operations for packed decimal data.
 - Conversion operations between different binary coded decimal and Java binary types.
 - Marshalling operations: marshalling and unmarshalling Java binary types, such as `short`, `int`, `long`, `float`, and `double`, to and from byte arrays.
+- External decimals support with all four sign configurations: sign embedded trailing, sign embedded leading, sign separate trailing, and sign separate leading. It also accommodates sign embedded trailing with spaces.
 
 You can gain a number of benefits by using the APIs provided:
 
 - Improved application performance by avoiding object creation and intermediate processing, which can also put pressure on the Java heap.
 - Hardware acceleration by automatically exploiting available hardware features on specific platforms.
 - Platform independence for applications that are developed to take advantage of Data Access Acceleration.
+- Validate the sign and digits of a given external decimal input before operating on the data.
 
 For more information, see the [API documentation](api-overview.md).
 
@@ -113,8 +115,7 @@ OpenJDK uses the in-built Java cryptographic implementation by default. However,
 
 ### Exploiting GPUs
 
-OpenJ9 provides both the [CUDA4J API](api-cuda.md) <!-- Link to API --> and the [GPU API](api-gpu.md), <!-- Link to API -->
-which enables you to develop applications that can take advantage of graphics processing unit (GPU) processing for suitable functions, such as sorting arrays. You can also enable the JIT compiler to offload certain processing tasks to a GPU by specifying the [`-Xjit:enableGPU`](xjit.md#enablegpu) option on the command line. When enabled, the JIT compiler determines when to offload tasks based on performance heuristics.
+OpenJ9 provides both the [CUDA4J API](api-cuda.md)<!-- Link to API --> and the [GPU API](api-gpu.md), <!-- Link to API -->which enables you to develop applications that can take advantage of graphics processing unit (GPU) processing for suitable functions, such as sorting arrays. You can also enable the JIT compiler to offload certain processing tasks to a GPU by specifying the [`-Xjit:enableGPU`](xjit.md#enablegpu) option on the command line. When enabled, the JIT compiler determines when to offload tasks based on performance heuristics.
 
 GPU processing is supported only on Linux little-endian systems, such as x86-64 and IBM Power LE, and Windows x86-64 systems. For more information about enabling GPU processing, see [Exploiting graphics processing units](https://www.ibm.com/support/knowledgecenter/SSYKE2_8.0.0/com.ibm.java.vm.80.doc/docs/gpu_overview.html).
 
@@ -140,7 +141,7 @@ If you do not require translations from the English language, the translation fi
 ## ![Start of content that applies to Java 16 and later](cr/java16plus.png) Using jpackage
 **(Linux, macOS, and Windows only)**
 
-You can use the `jpackage` utility to package a Java application into a platform-specific package that includes all of the necessary dependencies. Full details of the tool are available at [JEP 392: Packaging Tool](https://openjdk.org/jeps/392). Instructions for using it and the various options available, are documented in the Oracle Tool Specifications: [The jpackage Command](https://docs.oracle.com/en/java/javase/14/docs/specs/man/jpackage.html).
+You can use the `jpackage` utility to package a Java application into a platform-specific package that includes all of the necessary dependencies. Full details of the tool are available at [JEP 392: Packaging Tool](https://openjdk.org/jeps/392). Instructions for using it and the various options available are documented in the Oracle Tool Specifications: [The jpackage Command](https://docs.oracle.com/en/java/javase/14/docs/specs/man/jpackage.html).
 
 ## Troubleshooting
 

--- a/docs/version0.46.md
+++ b/docs/version0.46.md
@@ -35,6 +35,7 @@ The following new features and notable changes since version 0.45.0 are included
 - [New `-XX:[+|-]ShareOrphans` option added](#new-xx-shareorphans-option-added)
 - [New `-XX:[+|-]JITServerAOTCacheIgnoreLocalSCC` option added](#new-xx-jitserveraotcacheignorelocalscc-option-added)
 - [New `-XdynamicHeapAdjustment` option added](#new-xdynamicheapadjustment-option-added)
+- [A new Data Access Accelerator library API `com/ibm/dataaccess/ExternalDecimal.checkExternalDecimal` added](#a-new-data-access-accelerator-library-api-comibmdataaccessexternaldecimalcheckexternaldecimal-added)
 
 ## Features and changes
 
@@ -97,6 +98,12 @@ From this release onwards, the default behavior of the client when it uses the J
 By default, if a checkpoint is taken in a container with no memory limits and then restored in a container with memory limits, the restored VM instance does not detect the memory limits.
 
 You can now create a single image file and restore it on various nodes with different memory limits. The new option [`-XdynamicHeapAdjustment`](xdynamicheapadjustment.md) automatically adjusts the maximum Java heap size ([`-Xmx`](xms.md)) and minimum Java heap size ([`-Xms`](xms.md)) values such that they are within the physical memory limitations on the system. ![End of content that applies only to Java 11 and later](cr/java_close.png)
+
+### A new Data Access Accelerator library API `com/ibm/dataaccess/ExternalDecimal.checkExternalDecimal` added
+
+A new Data Access Accelerator (DAA) library class API `com/ibm/dataaccess/ExternalDecimal.checkExternalDecimal` is added to verify the validity of the sign and digits of a given external decimal input before operating on the data.
+
+For more information, see [Native Data Operations](introduction.md#native-data-operations).
 
 ## Known problems and full release information
 


### PR DESCRIPTION
https://github.com/eclipse-openj9/openj9-docs/issues/1504

OpenJ9 0.46.0 introduced a new Data Access Accelerator library class and API: com/ibm/dataaccess/ExternalDecimal.checkExternalDecimal. This is documented in 0.51.0 release.

Closes #1504
Signed-off-by: Sreekala Gopakumar sreekala.gopakumar@ibm.com