### PR TITLE
Security documentation change - ECDSA and PBE

### DIFF
--- a/docs/djdknativecrypto.md
+++ b/docs/djdknativecrypto.md
@@ -41,10 +41,12 @@ OpenSSL support is enabled by default for the following algorithms:
 
 - CBC
 - ChaCha20 and ChaCha20-Poly1305
-- EC key generation
 - ECDH key agreement
+- ECDSA signature
+- EC key generation
 - GCM
 - MD5
+- PBE cipher
 - RSA
 - SHA-224
 - SHA-256
@@ -69,11 +71,13 @@ If you want to turn off the algorithms individually, use the following system pr
 
 - [`-Djdk.nativeCBC`](djdknativecbc.md)
 - [`-Djdk.nativeChaCha20`](djdknativechacha20.md) (![Start of content that applies to Java 8 (LTS)](cr/java8.png) Not supported on Java 8. ![End of content that applies only to Java 8 (LTS)](cr/java_close_lts.png))
-- [`-Djdk.nativeGCM`](djdknativegcm.md)
-- [`-Djdk.nativeRSA`](djdknativersa.md)
 - [`-Djdk.nativeDigest`](djdknativedigest.md)
 - [`-Djdk.nativeEC`](djdknativeec.md)
+- [`-Djdk.nativeECDSA`](djdknativeecdsa.md)
 - [`-Djdk.nativeECKeyGen`](djdknativeeckeygen.md)
+- [`-Djdk.nativeGCM`](djdknativegcm.md)
+- [`-Djdk.nativePBE`](djdknativepbe.md)
+- [`-Djdk.nativeRSA`](djdknativersa.md)
 - ![Start of content that applies to Java 11 (LTS) and later](cr/java11plus.png) [`-Djdk.nativeXDHKeyAgreement`](djdknativexdhkeyagreement.md)
 - [`-Djdk.nativeXDHKeyGen`](djdknativexdhkeygen.md) ![End of content that applies to Java 11 (LTS) and later](cr/java_close_lts.png)
 

--- a/docs/djdknativeecdsa.md
+++ b/docs/djdknativeecdsa.md
@@ -1,0 +1,44 @@
+<!--
+* Copyright (c) 2017, 2025 IBM Corp. and others
+*
+* This program and the accompanying materials are made
+* available under the terms of the Eclipse Public License 2.0
+* which accompanies this distribution and is available at
+* https://www.eclipse.org/legal/epl-2.0/ or the Apache
+* License, Version 2.0 which accompanies this distribution and
+* is available at https://www.apache.org/licenses/LICENSE-2.0.
+*
+* This Source Code may also be made available under the
+* following Secondary Licenses when the conditions for such
+* availability set forth in the Eclipse Public License, v. 2.0
+* are satisfied: GNU General Public License, version 2 with
+* the GNU Classpath Exception [1] and GNU General Public
+* License, version 2 with the OpenJDK Assembly Exception [2].
+*
+* [1] https://www.gnu.org/software/classpath/license.html
+* [2] https://openjdk.org/legal/assembly-exception.html
+*
+* SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0 OR GPL-2.0-only WITH OpenJDK-assembly-exception-1.0
+-->
+
+# -Djdk.nativeECDSA
+
+This option enables or disables OpenSSL native cryptographic support for the ECDSA signature algorithm.
+
+## Syntax
+
+        -Djdk.nativeECDSA=[true|false]
+
+
+| Setting           | value    | Default                                                                        |
+|-------------------|----------|:------------------------------------------------------------------------------:|
+| `-Djdk.nativeECDSA` | true     | :fontawesome-solid-check:{: .yes aria-hidden="true"}<span class="sr-only">yes</span> |
+| `-Djdk.nativeECDSA` | false    |                                                                                |
+
+## Explanation
+
+OpenSSL support is enabled by default for the ECDSA signature algorithm. If you want to turn off support for this algorithm only, set this option to `false`. To turn off support for this and other algorithms, see the [`-Djdk.nativeCrypto`](djdknativecrypto.md) system property command line option.
+
+
+
+<!-- ==== END OF TOPIC ==== djdknativeecdsa.md ==== -->

--- a/docs/djdknativepbe.md
+++ b/docs/djdknativepbe.md
@@ -1,0 +1,43 @@
+<!--
+* Copyright (c) 2017, 2025 IBM Corp. and others
+*
+* This program and the accompanying materials are made
+* available under the terms of the Eclipse Public License 2.0
+* which accompanies this distribution and is available at
+* https://www.eclipse.org/legal/epl-2.0/ or the Apache
+* License, Version 2.0 which accompanies this distribution and
+* is available at https://www.apache.org/licenses/LICENSE-2.0.
+*
+* This Source Code may also be made available under the
+* following Secondary Licenses when the conditions for such
+* availability set forth in the Eclipse Public License, v. 2.0
+* are satisfied: GNU General Public License, version 2 with
+* the GNU Classpath Exception [1] and GNU General Public
+* License, version 2 with the OpenJDK Assembly Exception [2].
+*
+* [1] https://www.gnu.org/software/classpath/license.html
+* [2] https://openjdk.org/legal/assembly-exception.html
+*
+* SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0 OR GPL-2.0-only WITH OpenJDK-assembly-exception-1.0
+-->
+
+# -Djdk.nativePBE
+
+This option enables or disables OpenSSL native cryptographic support for the PBE cipher.
+
+## Syntax
+
+        -Djdk.nativePBE=[true|false]
+
+
+| Setting           | value    | Default                                                                        |
+|-------------------|----------|:------------------------------------------------------------------------------:|
+| `-Djdk.nativePBE` | true     | :fontawesome-solid-check:{: .yes aria-hidden="true"}<span class="sr-only">yes</span> |
+| `-Djdk.nativePBE` | false    |                                                                                |
+
+## Explanation
+
+OpenSSL support is enabled by default for the PBE cipher. If you want to turn off support for this algorithm only, set this option to `false`. To turn off support for this and other algorithms, see the [`-Djdk.nativeCrypto`](djdknativecrypto.md) system property command line option.
+
+
+<!-- ==== END OF TOPIC ==== djdknativepbe.md ==== -->

--- a/docs/openssl.md
+++ b/docs/openssl.md
@@ -23,7 +23,7 @@
 
 # OpenSSL
 
-OpenJDK uses the in-built Java&trade; cryptographic implementation by default but Eclipse OpenJ9&trade; also provides some support for the OpenSSL cryptographic library. OpenSSL is an open source cryptographic toolkit for Transport Layer Security (TLS) and Secure Sockets Layer (SSL) protocols, which is well established and used with many enterprise applications. Because it is a native library, OpenSSL might provide better performance. To use OpenSSL cryptographic acceleration, install OpenSSL 1.0.x, 1.1.x, or 3.x on your system. The OpenSSL V1.0.x, V1.1.x, and V3.x implementations are currently supported for the Digest, CBC, GCM, RSA, ECDH key agreement, and EC key generation algorithms. The OpenSSL V1.1.x and V3.x implementations are also supported for the ChaCha20 and ChaCha20-Poly1305 algorithms. The OpenSSL V1.1.1 onwards implementations are supported for the XDH key agreement and XDH key generation algorithms.
+OpenJDK uses the in-built Java&trade; cryptographic implementation by default but Eclipse OpenJ9&trade; also provides some support for the OpenSSL cryptographic library. OpenSSL is an open source cryptographic toolkit for Transport Layer Security (TLS) and Secure Sockets Layer (SSL) protocols, which is well established and used with many enterprise applications. Because it is a native library, OpenSSL might provide better performance. To use OpenSSL cryptographic acceleration, install OpenSSL 1.0.x, 1.1.x, or 3.x on your system. The OpenSSL V1.0.x, V1.1.x, and V3.x implementations are currently supported for the Digest, CBC, GCM, RSA, ECDH key agreement, PBE, and EC key generation algorithms. The OpenSSL V1.1.x and V3.x implementations are also supported for the ChaCha20 cipher, ChaCha20-Poly1305 cipher, and ECDSA signature algorithms. The OpenSSL V1.1.1 onwards implementations are supported for the XDH key agreement and XDH key generation algorithms.
 
 On Linux&reg; and AIX&reg; operating systems, the OpenSSL 1.0.x, 1.1.x, or 3.x library is expected to be found on the system path. If you use a package manager to install OpenSSL, the system path will be updated automatically. On Windows&trade; and MacOS&reg; the OpenSSL 3.x library is bundled. Later levels of some Linux operating systems also bundle OpenSSL 3.x.
 
@@ -36,15 +36,17 @@ OpenSSL support is enabled by default for all supported algorithms. If you want 
 Each algorithm can be disabled individually by setting the following system properties on the command line:
 
 
-- To turn off **Digest**, set `-Djdk.nativeDigest=false`
-- To turn off **ChaCha20** and **ChaCha20-Poly1305**, set `-Djdk.nativeChaCha20=false`. :fontawesome-solid-pencil:{: .note aria-hidden="true"} **Note:** ![Start of content that applies to Java 8 (LTS)](cr/java8.png) These algorithms are not supported on Java 8 ![End of content that applies only to Java 8 (LTS)](cr/java_close_lts.png)
-- To turn off **CBC**, set `-Djdk.nativeCBC=false`
-- To turn off **GCM**, set `-Djdk.nativeGCM=false`
-- To turn off **RSA**, set `-Djdk.nativeRSA=false`
-- To turn off **ECDH key agreement**, set `-Djdk.nativeEC=false`
-- To turn off **EC key generation**, set `-Djdk.nativeECKeyGen=false`
-- ![Start of content that applies to Java 11 (LTS) and later](cr/java11plus.png) To turn off **XDH key agreement**, set `-Djdk.nativeXDHKeyAgreement=false`
-- To turn off **XDH key generation**, set `-Djdk.nativeXDHKeyGen=false` ![End of content that applies to Java 11 (LTS) and later](cr/java_close_lts.png)
+- To turn off **Digest**, set [`-Djdk.nativeDigest=false`](djdknativedigest.md)
+- To turn off **ChaCha20** and **ChaCha20-Poly1305**, set [`-Djdk.nativeChaCha20=false`](djdknativechacha20.md). :fontawesome-solid-pencil:{: .note aria-hidden="true"} **Note:** ![Start of content that applies to Java 8 (LTS)](cr/java8.png) These algorithms are not supported on Java 8 ![End of content that applies only to Java 8 (LTS)](cr/java_close_lts.png)
+- To turn off **CBC**, set [`-Djdk.nativeCBC=false`](djdknativecbc.md)
+- To turn off **ECDH key agreement**, set [`-Djdk.nativeEC=false`](djdknativeec.md)
+- To turn off **ECDSA signature**, set [`-Djdk.nativeECDSA=false`](djdknativeecdsa.md)
+- To turn off **EC key generation**, set [`-Djdk.nativeECKeyGen=false`](djdknativeeckeygen.md)
+- To turn off **GCM**, set [`-Djdk.nativeGCM=false`](djdknativegcm.md)
+- To turn of **PBE cipher**, set [`-Djdk.nativePBE=false`](djdknativepbe.md)
+- To turn off **RSA**, set [`-Djdk.nativeRSA=false`](djdknativersa.md)
+- ![Start of content that applies to Java 11 (LTS) and later](cr/java11plus.png) To turn off **XDH key agreement**, set [`-Djdk.nativeXDHKeyAgreement=false`](djdknativexdhkeyagreement.md)
+- To turn off **XDH key generation**, set [`-Djdk.nativeXDHKeyGen=false`](djdknativexdhkeygen.md) ![End of content that applies to Java 11 (LTS) and later](cr/java_close_lts.png)
 
 You can turn off all the algorithms by setting the following system property on the command line:
 

--- a/docs/version0.51.md
+++ b/docs/version0.51.md
@@ -50,7 +50,7 @@ For more information, see [`maxstringlength`](xtrace.md#maxstringlength).
 
 AIX OpenJ9 builds now require version 16.1.0.10 or later of the [IBM XL C++ Runtime](https://www.ibm.com/support/pages/fix-list-xl-cc-runtime-aix#161X).
 
-<!--### ![Start of content that applies to Java 24 and later](cr/java24plus.png) New JDK 24 features
+<!--0.50.0 release cancelled ### ![Start of content that applies to Java 24 and later](cr/java24plus.png) New JDK 24 features
 
 The following features are supported by OpenJ9:
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -268,10 +268,12 @@ nav:
             - "-Djdk.nativeDigest"                                               : djdknativedigest.md
             - "-Djdk.nativeEC"                                                   : djdknativeec.md
             - "-Djdk.nativeECKeyGen"                                             : djdknativeeckeygen.md
+            - "-Djdk.nativeECDSA"                                                : djdknativeecdsa.md
+            - "-Djdk.nativeGCM"                                                  : djdknativegcm.md
+            - "-Djdk.nativePBE"                                                  : djdknativepbe.md
+            - "-Djdk.nativeRSA"                                                  : djdknativersa.md
             - "-Djdk.nativeXDHKeyAgreement"                                      : djdknativexdhkeyagreement.md
             - "-Djdk.nativeXDHKeyGen"                                            : djdknativexdhkeygen.md
-            - "-Djdk.nativeGCM"                                                  : djdknativegcm.md
-            - "-Djdk.nativeRSA"                                                  : djdknativersa.md
 
         - "JVM -X options" :
             - "Using -X options"                                                 : x_jvm_commands.md


### PR DESCRIPTION
Updated the OpenSSL topic with ECDSA signature algorithm and PBE cipher support for OpenSSL.

Signed-off-by: Sreekala Gopakumar sreekala.gopakumar@ibm.com