### PR TITLE
Update Requirements.txt

### DIFF
--- a/buildenv/requirements.txt
+++ b/buildenv/requirements.txt
@@ -24,7 +24,7 @@
 #
 babel==2.12.1
     # via mkdocs-material
-certifi==2024.7.4
+certifi==2025.4.26
     # via requests
 charset-normalizer==2.1.1
     # via requests
@@ -110,7 +110,7 @@ super-collections==0.5.0
     # via mkdocs-macros-plugin
 termcolor==2.2.0
     # via mkdocs-macros-plugin
-urllib3==1.26.19
+urllib3==2.4.0
     # via requests
 watchdog==2.2.1
     # via mkdocs


### PR DESCRIPTION
Pip's dependency conflict resolution. selenium 4.33.0 requires certifi>=2025.4.26, and urllib3[socks]~=2.4.0

Signed-off-by: Sreekala Gopakumar sreekala.gopakumar@ibm.com