### PR TITLE
Update Requirements.txt - certifi update

### DIFF
--- a/buildenv/requirements.txt
+++ b/buildenv/requirements.txt
@@ -26,7 +26,7 @@ babel==2.12.1
     # via mkdocs-material
 backrefs==5.8
     # via mkdocs-material
-certifi==2025.4.26
+certifi==2025.6.15
     # via requests
 charset-normalizer==2.1.1
     # via requests


### PR DESCRIPTION
Pip's dependency conflict resolution. selenium 4.34.1 requires certifi>=2025.6.15.

Signed-off-by: Sreekala Gopakumar sreekala.gopakumar@ibm.com