### PR TITLE
Update JFR documentation - CPU monitoring

### DIFF
--- a/docs/xxflightrecorder.md
+++ b/docs/xxflightrecorder.md
@@ -70,7 +70,7 @@ All JFR-related `jcmd` options might change in future releases.
 ```
 - ClassLoadingStatistics
 - CPUInformation
-- CPULoad
+- CPULoad (except z/OS)
 - ExecutionSample
 - GCHeapConfig
 - InitialEnvironmentVariable
@@ -86,7 +86,7 @@ All JFR-related `jcmd` options might change in future releases.
 - SystemGC
 - SystemProcess (Linux only)
 - ThreadContextSwitchRate
-- ThreadCPULoad
+- ThreadCPULoad (except z/OS)
 - ThreadDump
 - ThreadEnd
 - ThreadPark


### PR DESCRIPTION
https://github.com/eclipse-openj9/openj9-docs/issues/1579

CPULoad and ThreadCPULoad is not supported on zOS.

Closes #1579
Signed-off-by: Sreekala Gopakumar sreekala.gopakumar@ibm.com