### PR TITLE
-XX:IdleTuningGcOnIdle, -XX:IdleTuningCompactOnIdle on mac, zos

### DIFF
--- a/docs/xxidletuningcompactonidle.md
+++ b/docs/xxidletuningcompactonidle.md
@@ -23,7 +23,7 @@
 
 # -XX:\[+|-\]IdleTuningCompactOnIdle
 
-**(Linux&reg; only)**
+**(Linux&reg;, macOS&reg;, and z/OS&reg;)**
 
 :fontawesome-solid-triangle-exclamation:{: .warn aria-hidden="true"} **Warning:** From Eclipse OpenJ9&trade; version 0.23.0 this option has no effect.
 

--- a/docs/xxidletuninggconidle.md
+++ b/docs/xxidletuninggconidle.md
@@ -23,7 +23,7 @@
 
 # -XX:\[+|-\]IdleTuningGcOnIdle  
 
-**(Linux&reg; only)**
+**(Linux&reg;, macOS&reg;, and z/OS&reg;)**
 
 This option controls whether a garbage collection cycle takes place when the state of the Eclipse OpenJ9&trade; VM is set to idle. Compaction of the heap is also attempted during the idle GC when certain triggers are met.
 


### PR DESCRIPTION
[#1601](https://github.com/eclipse-openj9/openj9-docs/issues/1601)

Added macOS and z/OS to the options topics.

Closes [#1601](https://github.com/eclipse-openj9/openj9-docs/issues/1601)
Signed-off-by: Sreekala Gopakumar sreekala.gopakumar@ibm.com