### PR TITLE
ZIP64 support added

### DIFF
--- a/docs/openj9glossary.md
+++ b/docs/openj9glossary.md
@@ -132,6 +132,7 @@ This glossary provides definitions for technical terms used throughout the Eclip
 | **VM (Virtual Machine)** | The runtime environment that executes Java bytecode and manages application resources. | <ul><li>[New to Eclipse OpenJ9?](openj9_newuser.md)</li><li>[Garbage collection policies](gc.md)</li><li>[The JIT compiler](jit.md)</li></ul> |
 | **Warm Optimization** | The standard JIT optimization level used after startup for most methods that reach the invocation threshold. See [Optimization levels](jit.md#optimization-levels). | <ul><li>[The JIT compiler](jit.md)</li><li>[-Xjit / -Xnojit](xjit.md)</li></ul> |
 | **Write Barrier** | A mechanism that tracks object reference modifications to support concurrent GC operations. | <ul><li>[Garbage collection policies](gc.md)</li></ul> |
+| **ZIP64** | Extensions to the ZIP file format specification that overcomes the 4 GB size limitation of standard ZIP files. Supported on 64-bit platforms from the 0.60.0 release onwards for bootstrap class loading and shared classes cache. | <ul><li>[What's new in version 0.60.0](version0.60.md)</li><li>[Introduction to class data sharing](shrc.md)</li><li>[-Xzero](xzero.md)</li></ul> |
 
 ## Command-Line Options & Configuration
 

--- a/docs/openj9glossary.md
+++ b/docs/openj9glossary.md
@@ -132,13 +132,14 @@ This glossary provides definitions for technical terms used throughout the Eclip
 | **VM (Virtual Machine)** | The runtime environment that executes Java bytecode and manages application resources. | <ul><li>[New to Eclipse OpenJ9?](openj9_newuser.md)</li><li>[Garbage collection policies](gc.md)</li><li>[The JIT compiler](jit.md)</li></ul> |
 | **Warm Optimization** | The standard JIT optimization level used after startup for most methods that reach the invocation threshold. See [Optimization levels](jit.md#optimization-levels). | <ul><li>[The JIT compiler](jit.md)</li><li>[-Xjit / -Xnojit](xjit.md)</li></ul> |
 | **Write Barrier** | A mechanism that tracks object reference modifications to support concurrent GC operations. | <ul><li>[Garbage collection policies](gc.md)</li></ul> |
+| **ZIP64** | Extensions to the ZIP file format specification that eliminate the 4 GB size limitation of standard ZIP files. Supported on all platforms from the 0.62.0 release onwards for bootstrap class loading and the shared classes cache. | <ul><li>[What's new in version 0.62.0](version0.62.md)</li><li>[Introduction to class data sharing](shrc.md)</li></ul> |
 
 ## Command-Line Options & Configuration
 
 For a complete list of all command-line options, see:
 
 - [Standard command-line options](x_jvm_commands.md) - Options starting with `-X`
-- [Non-standard command-line options](xx_jvm_commands.md) - Options starting with `-XX:`
+- [Nonstandard command-line options](xx_jvm_commands.md) - Options starting with `-XX:`
 
 
 <!-- ==== END OF TOPIC ==== openj9glossary.md ==== -->

--- a/docs/shrc.md
+++ b/docs/shrc.md
@@ -92,6 +92,8 @@ For a set of best practices when using class data sharing, see [Creating a share
 
 When a VM loads a class and the class loader is enabled for class sharing, the VM looks in the shared classes cache to see if the class is already present. If the class is present and the classpath or URL to load the class is a match, the VM loads the class from the cache. Otherwise, it loads the class from the file system and writes it into the cache.
 
+:fontawesome-solid-pencil:{: .note aria-hidden="true"} **Note:** From the 0.60.0 release onwards, the VM supports ZIP files that use ZIP64 extensions for shared classes cache operations. This allows caching of classes from large JAR files that exceed the 4 GB size limitation of standard ZIP files. The VM automatically detects ZIP64 extensions and handles them appropriately.
+
 The VM detects file system updates by storing timestamp values into the cache and comparing the cached values with actual values. In this way, the VM detects when a class might be invalidated and can mark the class as *stale*. These operations happen transparently when classes are loaded, so users can modify and update as many classes as they like during the lifetime of a shared classes cache, knowing that the correct classes are always loaded. Stale classes are *redeemed* if the same class is subsequently fetched by the class loader from another VM and checked against the stale class in the cache.
 
 Occasionally, caches that are created from one version of the VM might not be compatible with caches that are created from a different version. This situation typically occurs when an update is made in OpenJ9 that changes the internal cache data structure. If a VM detects an incompatible cache at start up, it creates a new cache that can coexist, even if it has the same name. The VM detects a conflict by checking an internal shared classes cache generation number.
@@ -327,7 +329,7 @@ Although it is possible to combine partitions and modification contexts, this pr
 ## See also
 
 - [AOT compiler](aot.md)
-- [Class sharing article](https://developer.ibm.com/languages/java/tutorials/j-class-sharing-openj9/)
+<!--SG - This page is no longer available (22 May 2026) - [Class sharing article](https://developer.ibm.com/languages/java/tutorials/j-class-sharing-openj9/)-->
 - [Diagnosing problems with class data sharing](shrc_diag_util.md)
 
 

--- a/docs/shrc.md
+++ b/docs/shrc.md
@@ -92,6 +92,8 @@ For a set of best practices when using class data sharing, see [Creating a share
 
 When a VM loads a class and the class loader is enabled for class sharing, the VM looks in the shared classes cache to see if the class is already present. If the class is present and the classpath or URL to load the class is a match, the VM loads the class from the cache. Otherwise, it loads the class from the file system and writes it into the cache.
 
+:fontawesome-solid-pencil:{: .note aria-hidden="true"} **Note:** From the 0.62.0 release onwards, the VM supports ZIP files that use ZIP64 extensions for shared classes cache operations. This allows caching of classes from large JAR files that exceed the 4 GB size limitation of standard ZIP files. The VM automatically detects ZIP64 extensions and handles them appropriately.
+
 The VM detects file system updates by storing timestamp values into the cache and comparing the cached values with actual values. In this way, the VM detects when a class might be invalidated and can mark the class as *stale*. These operations happen transparently when classes are loaded, so users can modify and update as many classes as they like during the lifetime of a shared classes cache, knowing that the correct classes are always loaded. Stale classes are *redeemed* if the same class is subsequently fetched by the class loader from another VM and checked against the stale class in the cache.
 
 Occasionally, caches that are created from one version of the VM might not be compatible with caches that are created from a different version. This situation typically occurs when an update is made in OpenJ9 that changes the internal cache data structure. If a VM detects an incompatible cache at start up, it creates a new cache that can coexist, even if it has the same name. The VM detects a conflict by checking an internal shared classes cache generation number.
@@ -327,7 +329,7 @@ Although it is possible to combine partitions and modification contexts, this pr
 ## See also
 
 - [AOT compiler](aot.md)
-- [Class sharing article](https://developer.ibm.com/languages/java/tutorials/j-class-sharing-openj9/)
+<!--SG - This page is no longer available (22 May 2026) - [Class sharing article](https://developer.ibm.com/languages/java/tutorials/j-class-sharing-openj9/)-->
 - [Diagnosing problems with class data sharing](shrc_diag_util.md)
 
 

--- a/docs/version0.60.md
+++ b/docs/version0.60.md
@@ -1,0 +1,53 @@
+<!--
+* Copyright (c) 2017, 2026 IBM Corp. and others
+*
+* This program and the accompanying materials are made
+* available under the terms of the Eclipse Public License 2.0
+* which accompanies this distribution and is available at
+* https://www.eclipse.org/legal/epl-2.0/ or the Apache
+* License, Version 2.0 which accompanies this distribution and
+* is available at https://www.apache.org/licenses/LICENSE-2.0.
+*
+* This Source Code may also be made available under the
+* following Secondary Licenses when the conditions for such
+* availability set forth in the Eclipse Public License, v. 2.0
+* are satisfied: GNU General Public License, version 2 with
+* the GNU Classpath Exception [1] and GNU General Public
+* License, version 2 with the OpenJDK Assembly Exception [2].
+*
+* [1] https://www.gnu.org/software/classpath/license.html
+* [2] https://openjdk.org/legal/assembly-exception.html
+*
+* SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0 OR GPL-2.0-only WITH OpenJDK-assembly-exception-1.0
+-->
+
+# What's new in version 0.60.0
+
+The following new features and notable changes since version 0.59.0 are included in this release:
+
+- [New binaries and changes to supported environments](#binaries-and-supported-environments)
+- [ZIP64 extension support is added for 64-bit platforms](#zip64-extension-support-is-added-for-64-bit-platforms)
+
+## Features and changes
+
+### Binaries and supported environments
+
+Eclipse OpenJ9&trade; release 0.60.0 supports OpenJDK 8, 11, 17, 21, 25, and 26.
+
+To learn more about support for OpenJ9 releases, including OpenJDK levels and platform support, see [Supported environments](openj9_support.md).
+
+### ZIP64 extension support is added for 64-bit platforms
+
+On 64-bit platforms, the OpenJ9 VM now supports ZIP files that use ZIP64 extensions for bootstrap class loading and shared classes cache operations.
+
+This enhancement enables the VM to overcome the 4 GB size limitation of the standard ZIP files and work with large JAR or ZIP files.
+
+The VM automatically detects and handles ZIP files that contain ZIP64 extensions. The VM works with both standard ZIP files and ZIP files that use ZIP64 extensions.
+
+For more information about shared classes cache, see [Introduction to class data sharing](shrc.md).
+
+## Known problems and full release information
+
+To see known problems and a complete list of changes between Eclipse OpenJ9 v0.59.0 and v0.60.0 releases, see the [Release notes](https://github.com/eclipse-openj9/openj9/blob/master/doc/release-notes/0.60/0.60.md).
+
+<!-- ==== END OF TOPIC ==== version0.60.md ==== -->

--- a/docs/version0.62.md
+++ b/docs/version0.62.md
@@ -1,0 +1,55 @@
+<!--
+* Copyright (c) 2017, 2026 IBM Corp. and others
+*
+* This program and the accompanying materials are made
+* available under the terms of the Eclipse Public License 2.0
+* which accompanies this distribution and is available at
+* https://www.eclipse.org/legal/epl-2.0/ or the Apache
+* License, Version 2.0 which accompanies this distribution and
+* is available at https://www.apache.org/licenses/LICENSE-2.0.
+*
+* This Source Code may also be made available under the
+* following Secondary Licenses when the conditions for such
+* availability set forth in the Eclipse Public License, v. 2.0
+* are satisfied: GNU General Public License, version 2 with
+* the GNU Classpath Exception [1] and GNU General Public
+* License, version 2 with the OpenJDK Assembly Exception [2].
+*
+* [1] https://www.gnu.org/software/classpath/license.html
+* [2] https://openjdk.org/legal/assembly-exception.html
+*
+* SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0 OR GPL-2.0-only WITH OpenJDK-assembly-exception-1.0
+-->
+
+# What's new in version 0.62.0
+
+The following new features and notable changes since version 0.61.0 are included in this release:
+
+- [New binaries and changes to supported environments](#binaries-and-supported-environments)
+- [ZIP64 extension support is added](#zip64-extension-support-is-added)
+
+## Features and changes
+
+### Binaries and supported environments
+
+Eclipse OpenJ9&trade; release 0.62.0 supports OpenJDK 27.
+
+OpenJDK 27 with Eclipse OpenJ9 is *not* a long term support (LTS) release.
+
+To learn more about support for OpenJ9 releases, including OpenJDK levels and platform support, see [Supported environments](openj9_support.md).
+
+### ZIP64 extension support is added
+
+OpenJ9 VM now supports ZIP files that use ZIP64 extensions for bootstrap class loading and shared classes cache operations.
+
+This enhancement enables the VM to eliminate the 4 GB size limitation of standard ZIP files and work with large JAR or ZIP files.
+
+The VM automatically detects and handles ZIP files that contain ZIP64 extensions. The VM works with both standard ZIP files and ZIP files that use ZIP64 extensions.
+
+For more information about shared classes cache, see [Introduction to class data sharing](shrc.md).
+
+## Known problems and full release information
+
+To see known problems and a complete list of changes between Eclipse OpenJ9 v0.61.0 and v0.62.0 releases, see the [Release notes](https://github.com/eclipse-openj9/openj9/blob/master/doc/release-notes/0.62/0.62.md).
+
+<!-- ==== END OF TOPIC ==== version0.62.md ==== -->

--- a/docs/xzero.md
+++ b/docs/xzero.md
@@ -49,7 +49,7 @@ The following parameters are no longer supported. The options are parsed but do 
 | `-Xzero:sharezip`       | Enables the sharezip sub option      |
 | `-Xzero:nosharezip`     | Disables the sharezip sub option     |
 
-
+:fontawesome-solid-pencil:{: .note aria-hidden="true"} **Note:** From the 0.60.0 release onwards, the OpenJ9 VM supports ZIP files that use ZIP64 extensions, enabling support for JAR and ZIP archives larger than 4 GB. This support is independent of the `-Xzero` option settings.
 
 
 <!-- ==== END OF TOPIC ==== xzero.md ==== -->

--- a/docs/xzero.md
+++ b/docs/xzero.md
@@ -49,7 +49,6 @@ The following parameters are no longer supported. The options are parsed but do 
 | `-Xzero:sharezip`       | Enables the sharezip sub option      |
 | `-Xzero:nosharezip`     | Disables the sharezip sub option     |
 
-
-
+:fontawesome-solid-pencil:{: .note aria-hidden="true"} **Note:** From the 0.60.0 release onwards, the OpenJ9 VM supports ZIP files that use ZIP64 extensions, enabling support for JAR and ZIP archives larger than 4 GB. This support is independent of the `-Xzero` option settings.
 
 <!-- ==== END OF TOPIC ==== xzero.md ==== -->

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -101,6 +101,7 @@ nav:
 
     - "Release notes" :
         - "Overview"                                                             : openj9_releases.md
+        - "Version 0.60.0"                                                       : version0.60.md
         - "Version 0.59.0"                                                       : version0.59.md
         - "Version 0.58.0"                                                       : version0.58.md
         - "Version 0.57.0"                                                       : version0.57.md

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -101,6 +101,7 @@ nav:
 
     - "Release notes" :
         - "Overview"                                                             : openj9_releases.md
+        - "Version 0.62.0"                                                       : version0.62.md
         - "Version 0.61.0"                                                       : version0.61.md
         - "Version 0.60.0"                                                       : version0.60.md
         - "Version 0.59.0"                                                       : version0.59.md


### PR DESCRIPTION
https://github.com/eclipse-openj9/openj9-docs/issues/1701

Related topics updated with the ZIP64 support information.

Closes #1701
Signed-off-by: Sreekala Gopakumar sreekala.gopakumar@ibm.com